### PR TITLE
latest LTS 8 resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-7.4
+resolver: lts-8.23
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
On Arch Linux, `stack build` was failing with a linker error related to `tf-random` and `time`. This appeared to happen with any version of LTS 7.x. Switching to LTS 8 fixed the issue. 

Here's the error I was seeing prior to this change:
```
.stack/snapshots/x86_64-linux/lts-7.0/8.0.1/lib/x86_64-linux-ghc-8.0.1/tf-random-0.5-4z8OJUaXC1FRNfrLPFWAD/libHStf-random-0.5-4z8OJUaXC1FRNfrLPFWAD.a(Init.o):(.data.rel.ro+0x90): undefined reference to `timezm1zi6zi0zi1_DataziTimeziClockziCTimespec_getCTimespec1_closure'
```