### PR TITLE
Make withServer provide the actual port

### DIFF
--- a/src/Network/GRPC/HighLevel/Server/Unregistered.hs
+++ b/src/Network/GRPC/HighLevel/Server/Unregistered.hs
@@ -70,7 +70,7 @@ serverLoop ServerOptions{..} = do
   -- We run the loop in a new thread so that we can kill the serverLoop thread.
   -- Without this fork, we block on a foreign call, which can't be interrupted.
   tid <- async $ withGRPC $ \grpc ->
-    withServer grpc config $ \server -> do
+    withServer grpc config $ \server _port -> do
       dispatchLoop server
                    optLogger
                    optInitialMetadata

--- a/tests/LowLevelTests.hs
+++ b/tests/LowLevelTests.hs
@@ -343,7 +343,7 @@ testAuthMetadataPropagate = testCase "auth metadata inherited by children" $ do
 
     server = do
       threadDelaySecs 2
-      withGRPC $ \g -> withServer g server1ServerConf $ \s ->
+      withGRPC $ \g -> withServer g server1ServerConf $ \s _ ->
         withClient g server1ClientConf $ \c -> do
           let rm = head (normalMethods s)
           serverHandleNormalCall s rm mempty $ \call -> do
@@ -373,7 +373,7 @@ testAuthMetadataPropagate = testCase "auth metadata inherited by children" $ do
                   port = 50052
                 }
 
-    server2 = withGRPC $ \g -> withServer g server2ServerConf $ \s -> do
+    server2 = withGRPC $ \g -> withServer g server2ServerConf $ \s _ -> do
         let rm = head (normalMethods s)
         serverHandleNormalCall s rm mempty $ \_call -> do
           return ("server2 reply", mempty, StatusOk, "")
@@ -873,4 +873,6 @@ mgdClient :: ClientConfig -> GRPC -> Managed Client
 mgdClient conf g = managed $ withClient g conf
 
 mgdServer :: ServerConfig -> GRPC -> Managed Server
-mgdServer conf g = managed $ withServer g conf
+mgdServer conf g = managed withServer'
+  where
+    withServer' cont = withServer g conf $ \s _ -> cont s

--- a/tests/LowLevelTests/Op.hs
+++ b/tests/LowLevelTests/Op.hs
@@ -47,7 +47,7 @@ withClientServerUnaryCall :: GRPC
 withClientServerUnaryCall grpc f = do
   withClient grpc clientConf $ \c -> do
     crm <- clientRegisterMethodNormal c "/foo"
-    withServer grpc serverConf $ \s ->
+    withServer grpc serverConf $ \s _ ->
       withClientCall c crm 10 $ \cc -> do
         let srm = head (normalMethods s)
         -- NOTE: We need to send client ops here or else `withServerCall` hangs,


### PR DESCRIPTION
This PR proposes to pass the gRPC listening port to the continuation of `withServer`. This is useful if you pass port zero to the server, leaving the OS bind any available port, and want to get back the port number.

I have used this several times in tests where I had several servers.