### PR TITLE
Make serverRequestCall interruptible

### DIFF
--- a/src/Network/GRPC/LowLevel/CompletionQueue/Unregistered.hs
+++ b/src/Network/GRPC/LowLevel/CompletionQueue/Unregistered.hs
@@ -50,7 +50,14 @@ serverRequestCall s scq ccq =
       runExceptT $ case ce of
         C.CallOk -> do
           ExceptT $ do
-            r <- pluck' scq tag Nothing
+            let
+              rec = do
+                -- yield every second, for interruptibility
+                r <- pluck' scq tag (Just 1)
+                case r of
+                  Left GRPCIOTimeout -> rec
+                  _ -> return r
+            r <- rec
             dbug $ "pluck' finished: " ++ show r
             return r
           lift $


### PR DESCRIPTION
This PR proposes a way to make `Server`s stoppable. Currently, `Server`s are most of the time blocked in a uninterruptible foreign call (`pluck`), making them impossible to kill.

Instead of making a blocking foreign call without a timeout, we set a timeout of one second. This way, the thread returns in Haskell code (and thus is interruptible) at least every second. This is useful in order to be able to kill `Server`s, see https://github.com/awakesecurity/gRPC-haskell/issues/22.