### PR TITLE
Update`proto3-suite`, `proto3-wire`, and related deps

### DIFF
--- a/nix/optparse-applicative.nix
+++ b/nix/optparse-applicative.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, process
+, QuickCheck, stdenv, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "optparse-applicative";
+  version = "0.14.0.0";
+  sha256 = "06iwp1qsq0gjhnhxwyhdhldwvhlgcik6lx5jxpbb40fispyk4nxm";
+  libraryHaskellDepends = [
+    ansi-wl-pprint base process transformers transformers-compat
+  ];
+  testHaskellDepends = [ base bytestring QuickCheck ];
+  homepage = "https://github.com/pcapriotti/optparse-applicative";
+  description = "Utilities and combinators for parsing command line options";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/optparse-generic.nix
+++ b/nix/optparse-generic.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, bytestring, optparse-applicative, semigroups
+, stdenv, system-filepath, text, time, transformers, void
+}:
+mkDerivation {
+  pname = "optparse-generic";
+  version = "1.2.1";
+  sha256 = "1dk945dp98mwk1v4y0cky3z0ngmd29nbg6fbaaxnigcrgpbvkjml";
+  libraryHaskellDepends = [
+    base bytestring optparse-applicative semigroups system-filepath
+    text time transformers void
+  ];
+  description = "Auto-generate a command-line parser for your datatype";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/proto3-suite.nix
+++ b/nix/proto3-suite.nix
@@ -10,8 +10,8 @@ mkDerivation {
   version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-suite";
-    sha256 = "0pmpnjyw381ksy63nqa9bafzz8gs08k7h3jad7a7hyh1ygxjv19i";
-    rev = "88ea97236ac5a03c918badb0961db63f2b0e038c";
+    sha256 = "11zrkpnr5i3axw8m0dxi0camffdmcz0a0dnd6ivsw8s187a1k07c";
+    rev = "683f100ca3200594f3dc4a723e52cc5b5e237053";
   };
   isLibrary = true;
   isExecutable = true;

--- a/nix/proto3-suite.nix
+++ b/nix/proto3-suite.nix
@@ -10,8 +10,8 @@ mkDerivation {
   version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-suite";
-    sha256 = "11zrkpnr5i3axw8m0dxi0camffdmcz0a0dnd6ivsw8s187a1k07c";
-    rev = "683f100ca3200594f3dc4a723e52cc5b5e237053";
+    sha256 = "1imhijvbliax8n2sz74jwwyb0m6zy8v1xkmixlm6vchwicn2ka3k";
+    rev = "d9d0282978a785385c47642a9a46037e4263a87d";
   };
   isLibrary = true;
   isExecutable = true;

--- a/nix/proto3-suite.nix
+++ b/nix/proto3-suite.nix
@@ -1,6 +1,7 @@
 { mkDerivation, base, bytestring, cereal, containers, deepseq
-, fetchgit, filepath, haskell-src, mtl, optparse-generic, parsec
-, parsers, pretty, pretty-show, proto3-wire, QuickCheck, safe
+, doctest, fetchgit, foldl, haskell-src, lens, mtl
+, neat-interpolation, optparse-generic, parsec, parsers, pretty
+, pretty-show, proto3-wire, QuickCheck, range-set-list, safe
 , semigroups, stdenv, system-filepath, tasty, tasty-hunit
 , tasty-quickcheck, text, transformers, turtle, vector
 }:
@@ -8,22 +9,24 @@ mkDerivation {
   pname = "proto3-suite";
   version = "0.1.0.0";
   src = fetchgit {
-    url = "https://github.com/awakenetworks/proto3-suite";
-    sha256 = "1wqs209sfwjiwvpv8zz49jk9l6pivqz06r0m1rfxvsdmxh80kp7d";
-    rev = "48d452d42e8d73acfa88a56a54586d17bae711db";
+    url = "https://github.com/awakesecurity/proto3-suite";
+    sha256 = "0pmpnjyw381ksy63nqa9bafzz8gs08k7h3jad7a7hyh1ygxjv19i";
+    rev = "88ea97236ac5a03c918badb0961db63f2b0e038c";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring cereal containers deepseq filepath haskell-src mtl
-    parsec parsers pretty pretty-show proto3-wire QuickCheck safe
-    semigroups text transformers vector
+    base bytestring cereal containers deepseq foldl haskell-src lens
+    mtl neat-interpolation parsec parsers pretty pretty-show
+    proto3-wire QuickCheck safe semigroups system-filepath text
+    transformers turtle vector
   ];
   executableHaskellDepends = [
-    base optparse-generic system-filepath turtle
+    base containers optparse-generic proto3-wire range-set-list
+    system-filepath text turtle
   ];
   testHaskellDepends = [
-    base bytestring cereal pretty-show proto3-wire QuickCheck
+    base bytestring cereal doctest pretty-show proto3-wire QuickCheck
     semigroups tasty tasty-hunit tasty-quickcheck text transformers
     turtle vector
   ];

--- a/nix/proto3-wire.nix
+++ b/nix/proto3-wire.nix
@@ -6,9 +6,9 @@ mkDerivation {
   pname = "proto3-wire";
   version = "1.0.0";
   src = fetchgit {
-    url = "https://github.com/awakenetworks/proto3-wire";
-    sha256 = "1979pccp8c8wvl69r203mji51c8s59mccng6zrw3kf2s1wz5xxqg";
-    rev = "8178cc717eb1c438272a7f451862590a8b2d41ff";
+    url = "https://github.com/awakesecurity/proto3-wire";
+    sha256 = "0pcacsz33n84rkc6yi99yq2dy4fisrhqpfbkqa3nfsjqhlw43gcf";
+    rev = "077b7e329fd7f43b0628c23b83c5e2e05334002e";
   };
   libraryHaskellDepends = [
     base bytestring cereal containers deepseq hashable QuickCheck safe

--- a/nix/turtle.nix
+++ b/nix/turtle.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
+, directory, doctest, foldl, hostname, managed, optional-args
+, optparse-applicative, process, semigroups, stdenv, stm
+, system-fileio, system-filepath, temporary, text, time
+, transformers, unix, unix-compat
+}:
+mkDerivation {
+  pname = "turtle";
+  version = "1.3.6";
+  sha256 = "0fr8p6rnk2lrsgbfh60jlqcjr0nxrh3ywxsj5d4psck0kgyhvg1m";
+  libraryHaskellDepends = [
+    ansi-wl-pprint async base bytestring clock directory foldl hostname
+    managed optional-args optparse-applicative process semigroups stm
+    system-fileio system-filepath temporary text time transformers unix
+    unix-compat
+  ];
+  testHaskellDepends = [ base doctest system-filepath temporary ];
+  description = "Shell programming, Haskell-style";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/release.nix
+++ b/release.nix
@@ -175,6 +175,12 @@ let
 
       haskellPackages = pkgs.haskellPackages.override {
         overrides = haskellPackagesNew: haskellPackagesOld: rec {
+          optparse-applicative =
+            haskellPackagesNew.callPackage ./nix/optparse-applicative.nix { };
+
+          optparse-generic =
+            haskellPackagesNew.callPackage ./nix/optparse-generic.nix { };
+
           proto3-wire =
             haskellPackagesNew.callPackage ./nix/proto3-wire.nix { };
 
@@ -218,10 +224,6 @@ let
                     grpcio-tools
                   ]);
 
-                  # So users can use `stack` inside of `nix-shell` if they do not
-                  # already have it installed.
-                  stack = haskellPackages.stack;
-
                 in rec {
                   buildDepends = [
                     pkgs.makeWrapper
@@ -260,9 +262,13 @@ let
                   shellHook = (oldDerivation.shellHook or "") + ''
                     export DYLD_LIBRARY_PATH=${grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
                     # This lets us use our custom ghc and python environments in the shell.
-                    export PATH=${stack}/bin:${ghc}/bin:${python}/bin''${PATH:+:}$PATH
+                    export PATH=${ghc}/bin:${python}/bin''${PATH:+:}$PATH
                   '';
                 });
+
+          turtle =
+            haskellPackagesNew.callPackage ./nix/turtle.nix { };
+
         };
       };
     };

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,11 +9,11 @@ packages:
 - '.'
 - location:
     git: git@github.com:awakenetworks/proto3-suite.git
-    commit: 10f592cdd5349e33d4924b066d4f6e27ada5e5c5
+    commit: d9d0282978a785385c47642a9a46037e4263a87d
   extra-dep: true
 - location:
     git: git@github.com:awakenetworks/proto3-wire.git
-    commit: 4cf2f349cbf27ef36af28ae51e2712d6cf5f7723
+    commit: 077b7e329fd7f43b0628c23b83c5e2e05334002e
   extra-dep: true
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps: [managed-1.0.5]

--- a/tests/GeneratedTests.hs
+++ b/tests/GeneratedTests.hs
@@ -21,7 +21,7 @@ testServerGeneration = testCase "server generation" $ do
   mktree hsTmpDir
   mktree pyTmpDir
 
-  compileSimpleDotProto
+  compileDotProtoFileOrDie hsTmpDir ["tests"] "simple.proto"
 
   do exitCode <- proc "tests/simple-server.sh" [hsTmpDir] empty
      exitCode @?= ExitSuccess
@@ -49,7 +49,7 @@ testClientGeneration = testCase "client generation" $ do
   mktree hsTmpDir
   mktree pyTmpDir
 
-  compileSimpleDotProto
+  compileDotProtoFileOrDie hsTmpDir ["tests"] "simple.proto"
 
   do exitCode <- proc "tests/simple-client.sh" [hsTmpDir] empty
      exitCode @?= ExitSuccess
@@ -75,13 +75,3 @@ testClientGeneration = testCase "client generation" $ do
 hsTmpDir, pyTmpDir :: IsString a => a
 hsTmpDir = "tests/tmp"
 pyTmpDir = "tests/py-tmp"
-
-compileSimpleDotProto :: IO ()
-compileSimpleDotProto =
-  do dpRes <- readDotProtoWithContext [] "tests/simple.proto"
-     case dpRes of
-       Left err -> fail (show err)
-       Right (dp, ctxt) ->
-         case renderHsModuleForDotProto dp ctxt of
-           Left err -> fail ("compileSimpleDotProto: Error compiling test.proto: " <> show err)
-           Right hsSrc -> writeFile (hsTmpDir ++ "/Simple.hs") hsSrc

--- a/tests/GeneratedTests.hs
+++ b/tests/GeneratedTests.hs
@@ -1,3 +1,4 @@
+
 {-# LANGUAGE OverloadedStrings #-}
 
 module GeneratedTests where
@@ -77,7 +78,7 @@ pyTmpDir = "tests/py-tmp"
 
 compileSimpleDotProto :: IO ()
 compileSimpleDotProto =
-  do dpRes <- readDotProtoWithContext "tests/simple.proto"
+  do dpRes <- readDotProtoWithContext [] "tests/simple.proto"
      case dpRes of
        Left err -> fail (show err)
        Right (dp, ctxt) ->


### PR DESCRIPTION
The primary purpose of this PR is to update the `proto3-suite` dependency to pick up the recent changes to `compile-proto-file`, parser bugfixes, and related code generation changes.

- `proto3-suite` => `d9d0282`
- `proto3-wire` => `077b7e3`
- Adds nix exprs for updated versions of `optparse-{applicative,generic}`, `turtle`
- Use new `compileDotProtoFileOrDie` helper function from `proto3-suite`