### PR TITLE
Expose `GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH` channel arg

### DIFF
--- a/cbits/grpc_haskell.c
+++ b/cbits/grpc_haskell.c
@@ -438,6 +438,8 @@ char* translate_arg_key(enum supported_arg_key key){
       return GRPC_ARG_PRIMARY_USER_AGENT_STRING;
     case user_agent_suffix_key:
       return GRPC_ARG_SECONDARY_USER_AGENT_STRING;
+    case max_receive_message_length_key:
+      return GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH;
     default:
       return "unknown_arg_key";
   }

--- a/include/grpc_haskell.h
+++ b/include/grpc_haskell.h
@@ -154,7 +154,8 @@ enum supported_arg_key {
   compression_algorithm_key = 0,
   compression_level_key,
   user_agent_prefix_key,
-  user_agent_suffix_key
+  user_agent_suffix_key,
+  max_receive_message_length_key,
 };
 
 grpc_arg* create_arg_array(size_t n);

--- a/src/Network/GRPC/Unsafe/ChannelArgs.chs
+++ b/src/Network/GRPC/Unsafe/ChannelArgs.chs
@@ -1,4 +1,3 @@
-{-# LANGUAGE MultiWayIf      #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Network.GRPC.Unsafe.ChannelArgs where

--- a/src/Network/GRPC/Unsafe/ChannelArgs.chs
+++ b/src/Network/GRPC/Unsafe/ChannelArgs.chs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiWayIf      #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Network.GRPC.Unsafe.ChannelArgs where
@@ -6,6 +7,7 @@ import           Control.Exception
 import           Control.Monad
 import           Foreign.Marshal.Alloc (malloc, free)
 import           Foreign.Storable
+import           Numeric.Natural
 
 #include <grpc/grpc.h>
 #include <grpc/status.h>
@@ -47,9 +49,10 @@ data ArgValue = StringArg String | IntArg Int
 -- | Supported arguments for a channel. More cases will be added as we figure
 -- out what they are.
 data Arg = CompressionAlgArg CompressionAlgorithm
-           | CompressionLevelArg CompressionLevel
-           | UserAgentPrefix String
-           | UserAgentSuffix String
+         | CompressionLevelArg CompressionLevel
+         | UserAgentPrefix String
+         | UserAgentSuffix String
+         | MaxReceiveMessageLength Natural
   deriving (Show, Eq)
 
 {#fun create_string_arg as ^ {`GrpcArg', `Int', `ArgKey', `String'} -> `()'#}
@@ -67,6 +70,9 @@ createArg array (UserAgentPrefix prefix) i =
   createStringArg array i UserAgentPrefixKey prefix
 createArg array (UserAgentSuffix suffix) i =
   createStringArg array i UserAgentSuffixKey suffix
+createArg array (MaxReceiveMessageLength n) i =
+  createIntArg array i MaxReceiveMessageLengthKey $
+    fromIntegral (min n (fromIntegral (maxBound :: Int)))
 
 createChannelArgs :: [Arg] -> IO GrpcChannelArgs
 createChannelArgs args = do


### PR DESCRIPTION
This PR exposes the `GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH` channel argument and adds a unittest to check expected behavior.

Without the ability to tweak this parameter, we get errors raised from the `grpc` C core whenever the default payload size of 4MB is exceeded.

