### PR TITLE
Update to Nixpkgs 17.09

### DIFF
--- a/nix/grpc.nix
+++ b/nix/grpc.nix
@@ -1,4 +1,5 @@
-{ pkgs, stdenv, lib, fetchgit, autoconf, automake, libtool, which, zlib, openssl
+{ darwin, stdenv, lib, fetchgit, autoconf, automake, libtool, which, zlib
+, openssl
 }:
 
 stdenv.mkDerivation rec {
@@ -10,9 +11,19 @@ stdenv.mkDerivation rec {
     url    = "https://github.com/grpc/grpc.git";
     sha256 = "19ldbjlnbc287hkaylsigm8w9fai2bjdbfxk6315kl75cq54iprr";
   };
-  preInstall  = "export prefix";
-  buildInputs =
-    (if stdenv.isDarwin then [ pkgs.darwin.cctools ] else []) ++ [
+
+  # `grpc`'s `Makefile` does some magic to detect the correct `ld` and `strip`
+  # to use along with their flags, too.  If Nix supplies `$LD` and `$STRIP` then
+  # this auto-detection fails and the build fails, which is why we unset the
+  # environment variables here and let the `Makefile` set them.
+  preBuild = ''
+    unset LD
+    unset STRIP
+  '';
+
+  preInstall = "export prefix";
+
+  buildInputs = [
     autoconf
     automake
     libtool
@@ -20,4 +31,10 @@ stdenv.mkDerivation rec {
     zlib
     openssl
   ];
+
+  # Some versions of `ar` (such as the one provided by OS X) require an explicit
+  # `-r` flag, whereas other versions assume `-r` is the default if no mode is
+  # specified.  For example, OS X requires the `-r` flag, so as a precaution we
+  # always specify the flag.
+  AROPTS = "-r";
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -7,6 +7,6 @@
 # The SHA256 will be printed as the last line of stdout.
 
 import ./fetch-nixpkgs.nix {
-  rev    = "1849e695b00a54cda86cb75202240d949c10c7ce";
-  sha256 = "1riv7n11rqbfdnikr2wm263fcppzh0760kqhwn5gscl89qmliw2y";
+   rev    = "74286ec9e76be7cd00c4247b9acb430c4bd9f1ce";
+   sha256 = "0njb3qd2wxj7gil8y61lwh7zacmvr6zklv67w5zmvifi1fvalvdg";
 }

--- a/release.nix
+++ b/release.nix
@@ -277,7 +277,7 @@ let
                 });
 
           swagger2 =
-            pkgs.haskell.lib.dontHaddock (haskellPackagesNew.callPackage ./nix/swagger2.nix { });
+            pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.dontHaddock (haskellPackagesNew.callPackage ./nix/swagger2.nix { }));
 
           turtle =
             haskellPackagesNew.callPackage ./nix/turtle.nix { };

--- a/tests/LowLevelTests.hs
+++ b/tests/LowLevelTests.hs
@@ -22,6 +22,7 @@ import           Data.List                                 (find)
 import qualified Data.Map.Strict                           as M
 import qualified Data.Set                                  as S
 import           GHC.Exts                                  (fromList, toList)
+import           Network.GRPC.Unsafe.ChannelArgs           (Arg(..))
 import           Network.GRPC.LowLevel
 import qualified Network.GRPC.LowLevel.Call.Unregistered   as U
 import qualified Network.GRPC.LowLevel.Client.Unregistered as U


### PR DESCRIPTION
This is a "shallow" update, meaning that there are still several dependencies
(such as `grpc` or Haskell packages) that are still pinned and those pins might
not be necessary any longer after this change.