### PR TITLE
Remove proto3-suite dependency and fix a README.md typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ used to give you a development environment where you can use the `cabal` and
 `stack` toolchains for development and testing:
 
 ```bash
-$ nix-shell release-nix -A grpc-haskell.env
+$ nix-shell release.nix -A grpc-haskell.env
 [nix-shell]$ cabal configure --enable-tests && cabal build && cabal test
 ```
 

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -26,7 +26,6 @@ library
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4
     , transformers
-    , proto3-suite
     , proto3-wire
 
     , async ==2.1.*


### PR DESCRIPTION
The `proto3-suite` dependency in `core` is now useless (whups). `proto3-wire` should be taken out too, but that's slightly more controversial. Separate PR coming.