### PR TITLE
Remove `proto3-wire` dependency from `core` package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ used to give you a development environment where you can use the `cabal` and
 `stack` toolchains for development and testing:
 
 ```bash
-$ nix-shell release-nix -A grpc-haskell.env
+$ nix-shell release.nix -A grpc-haskell.env
 [nix-shell]$ cabal configure --enable-tests && cabal build && cabal test
 ```
 

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -26,7 +26,6 @@ library
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4
     , transformers
-    , proto3-suite
     , proto3-wire
 
     , async ==2.1.*

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -26,8 +26,6 @@ library
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4
     , transformers
-    , proto3-wire
-
     , async ==2.1.*
     , tasty >= 0.11 && <0.12
     , tasty-hunit >= 0.9 && <0.10

--- a/core/src/Network/GRPC/LowLevel/GRPC.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC.hs
@@ -21,7 +21,6 @@ import           Data.Typeable
 import qualified Network.GRPC.Unsafe    as C
 import qualified Network.GRPC.Unsafe.Op as C
 import qualified Network.GRPC.Unsafe.Metadata as C
-import           Proto3.Wire.Decode     (ParseError)
 
 -- | Functions as a proof that the gRPC core has been started. The gRPC core
 -- must be initialized to create any gRPC state, so this is a requirement for
@@ -50,7 +49,7 @@ data GRPCIOError = GRPCIOCallError C.CallError
                    | GRPCIOUnknownError
                    | GRPCIOBadStatusCode C.StatusCode C.StatusDetails
 
-                   | GRPCIODecodeError ParseError
+                   | GRPCIODecodeError String
                    | GRPCIOInternalUnexpectedRecv String -- debugging description
                    | GRPCIOHandlerException String
   deriving (Eq, Show, Typeable)

--- a/src/Network/GRPC/HighLevel/Server.hs
+++ b/src/Network/GRPC/HighLevel/Server.hs
@@ -53,7 +53,7 @@ convertServerHandler :: (Message a, Message b)
                      => ServerHandler a b
                      -> ServerHandlerLL
 convertServerHandler f c = case fromByteString (payload c) of
-  Left x  -> CE.throw (GRPCIODecodeError x)
+  Left x  -> CE.throw (GRPCIODecodeError $ show x)
   Right x -> do (y, tm, sc, sd) <- f (fmap (const x) c)
                 return (toBS y, tm, sc, sd)
 
@@ -99,7 +99,7 @@ convertServerWriterHandler f c send =
   f (convert <$> c) (convertSend send)
   where
     convert bs = case fromByteString bs of
-      Left x  -> CE.throw (GRPCIODecodeError x)
+      Left x  -> CE.throw (GRPCIODecodeError $ show x)
       Right x -> x
 
 type ServerRWHandler a b
@@ -129,7 +129,7 @@ convertRecv =
     case msg of
       Nothing -> return Nothing
       Just bs -> case fromByteString bs of
-                   Left x  -> Left (GRPCIODecodeError x)
+                   Left x  -> Left (GRPCIODecodeError $ show x)
                    Right x -> return (Just x)
 
 convertSend :: Message a => StreamSend ByteString -> StreamSend a


### PR DESCRIPTION
Ok, using `String` in errors is somewhat commonplace, in that `data` declaration even. But is it frowned upon? Thoughts?