### PR TITLE
Fix nixpkgs sha256 and update instructions to fetch new hash

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,12 +1,12 @@
 # Given a Git revision hash `<rev>`, you get the new SHA256 by running:
 #
 # ```bash
-# $ nix-prefetch-url "https://github.com/NixOS/nixpkgs/archive/<rev>.tar.gz"
+# $ nix-prefetch-url --unpack "https://github.com/NixOS/nixpkgs/archive/<rev>.tar.gz"
 # ```
 #
 # The SHA256 will be printed as the last line of stdout.
 
 import ./fetch-nixpkgs.nix {
    rev    = "74286ec9e76be7cd00c4247b9acb430c4bd9f1ce";
-   sha256 = "0njb3qd2wxj7gil8y61lwh7zacmvr6zklv67w5zmvifi1fvalvdg";
+   sha256 = "13ydgpzl5nix4gc358iy9zjd5nrrpbpwpxmfhis4aai2zmkja3ak";
 }


### PR DESCRIPTION
Trying out nix for the first time, but `nix-build release.nix -A grpc-haskell` wasn't working due to an invalid hash. After some digging figured out how to get the valid hash that worked for me on a freshly installed nix 2.0 on a mac.