### PR TITLE
Fix the output of the nixpkgs derivation and make the pin forwards compatible with Nix 2.0

### DIFF
--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -18,8 +18,8 @@ ifThenElse {
       url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 
       # builtins.fetchTarball does not need the sha256 hash of the
-      # unpacked tarball but it _does_ need the fixed-output sha256
-      # hash.
+      # packed and compressed tarball but it _does_ need the
+      # fixed-output sha256 hash.
       sha256 = outputSha256;
     });
 

--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -16,7 +16,11 @@ ifThenElse {
   thenValue = (
     builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-      inherit sha256;
+
+      # builtins.fetchTarball does not need the sha256 hash of the
+      # unpacked tarball but it _does_ need the fixed-output sha256
+      # hash.
+      sha256 = outputSha256;
     });
 
   # This hack should at least work for Nix 1.11

--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -1,5 +1,6 @@
 { rev                             # The Git revision of nixpkgs to fetch
 , sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 output hash
 , system ? builtins.currentSystem # This is overridable if necessary
 }:
 
@@ -34,7 +35,7 @@ ifThenElse {
         "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
       '';
 
-      nixpkgs = builtins.derivation {
+      nixpkgs = builtins.derivation ({
         name = "nixpkgs-${builtins.substring 0 6 rev}";
 
         builder = builtins.storePath builtin-paths.shell;
@@ -46,6 +47,10 @@ ifThenElse {
         tar       = builtins.storePath builtin-paths.tar;
         gzip      = builtins.storePath builtin-paths.gzip;
         coreutils = builtins.storePath builtin-paths.coreutils;
-      };
+      } // (if null == outputSha256 then { } else {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = outputSha256;
+      }));
     }).nixpkgs);
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -7,6 +7,7 @@
 # The SHA256 will be printed as the last line of stdout.
 
 import ./fetch-nixpkgs.nix {
-   rev    = "74286ec9e76be7cd00c4247b9acb430c4bd9f1ce";
-   sha256 = "0njb3qd2wxj7gil8y61lwh7zacmvr6zklv67w5zmvifi1fvalvdg";
+  rev          = "74286ec9e76be7cd00c4247b9acb430c4bd9f1ce";
+  sha256       = "0njb3qd2wxj7gil8y61lwh7zacmvr6zklv67w5zmvifi1fvalvdg";
+  outputSha256 = "13ydgpzl5nix4gc358iy9zjd5nrrpbpwpxmfhis4aai2zmkja3ak";
 }


### PR DESCRIPTION
This change fixes a forwards compatibility issue raised by #51 and also ensures the `nixpkgs` derivation is a fixed-output derivation for nix =< (1.12).

CC: @jvliwanag