### PR TITLE
Add a comment to ClientReaderRequest.

### DIFF
--- a/src/Network/GRPC/HighLevel/Client.hs
+++ b/src/Network/GRPC/HighLevel/Client.hs
@@ -55,6 +55,9 @@ data ClientRequest (streamType :: GRPCMethodType) request response where
   ClientNormalRequest :: request -> TimeoutSeconds -> MetadataMap -> ClientRequest 'Normal request response
   ClientWriterRequest :: TimeoutSeconds -> MetadataMap -> (StreamSend request -> IO ()) -> ClientRequest 'ClientStreaming request response
   ClientReaderRequest :: request -> TimeoutSeconds -> MetadataMap -> (MetadataMap -> StreamRecv response -> IO ()) -> ClientRequest 'ServerStreaming request response
+    -- ^ The final field will be invoked once, and it should repeatedly
+    -- invoke its final argument (of type @(StreamRecv response)@)
+    -- in order to obtain the streaming response incrementally.
   ClientBiDiRequest :: TimeoutSeconds -> MetadataMap -> (MetadataMap -> StreamRecv response -> StreamSend request -> WritesDone -> IO ()) -> ClientRequest 'BiDiStreaming request response
 
 data ClientResult (streamType :: GRPCMethodType) response where


### PR DESCRIPTION
It was not obvious from the type how many times the
final field of ClientReaderRequest would be invoked.
(Assuming it is invoked once per stream increment
results in a hang, which can be confusing.)