### PR TITLE
Add max metadata size option

### DIFF
--- a/core/cbits/grpc_haskell.c
+++ b/core/cbits/grpc_haskell.c
@@ -440,6 +440,8 @@ char* translate_arg_key(enum supported_arg_key key){
       return GRPC_ARG_SECONDARY_USER_AGENT_STRING;
     case max_receive_message_length_key:
       return GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH;
+    case max_metadata_size_key:
+      return GRPC_ARG_MAX_METADATA_SIZE;
     default:
       return "unknown_arg_key";
   }

--- a/core/include/grpc_haskell.h
+++ b/core/include/grpc_haskell.h
@@ -156,6 +156,7 @@ enum supported_arg_key {
   user_agent_prefix_key,
   user_agent_suffix_key,
   max_receive_message_length_key,
+  max_metadata_size_key,
 };
 
 grpc_arg* create_arg_array(size_t n);

--- a/core/src/Network/GRPC/Unsafe/ChannelArgs.chs
+++ b/core/src/Network/GRPC/Unsafe/ChannelArgs.chs
@@ -52,6 +52,7 @@ data Arg = CompressionAlgArg CompressionAlgorithm
          | UserAgentPrefix String
          | UserAgentSuffix String
          | MaxReceiveMessageLength Natural
+         | MaxMetadataSize Natural
   deriving (Show, Eq)
 
 {#fun create_string_arg as ^ {`GrpcArg', `Int', `ArgKey', `String'} -> `()'#}
@@ -71,6 +72,9 @@ createArg array (UserAgentSuffix suffix) i =
   createStringArg array i UserAgentSuffixKey suffix
 createArg array (MaxReceiveMessageLength n) i =
   createIntArg array i MaxReceiveMessageLengthKey $
+    fromIntegral (min n (fromIntegral (maxBound :: Int)))
+createArg array (MaxMetadataSize n) i =
+  createIntArg array i MaxMetadataSizeKey $
     fromIntegral (min n (fromIntegral (maxBound :: Int)))
 
 createChannelArgs :: [Arg] -> IO GrpcChannelArgs


### PR DESCRIPTION
GRPC has a max metadata size option: 'grpc.max_metadata_size'. I tried to integrate it the way other client arguments are integrated. This is useful if you want to return large messages as errors in the `StatusDetails` field, since this is transferred as part of the headers.