### PR TITLE
Port grpc-haskell[-core] to ghc-8.6 and modern tasty.

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -21,8 +21,8 @@ library
       base >=4.8 && <5.0
     , clock >=0.6.0 && <0.8.0
     , bytestring ==0.10.*
-    , stm == 2.4.*
-    , containers ==0.5.*
+    , stm >=2.4 && <2.6
+    , containers >=0.5 && <0.7
     , managed >= 1.0.0 && < 1.1
     , transformers
     , sorted-list >=0.1.6.1 && <=0.3
@@ -80,11 +80,11 @@ test-suite tests
     , bytestring ==0.10.*
     , unix
     , time
-    , async ==2.1.*
-    , tasty >= 0.11 && <0.12
-    , tasty-hunit >= 0.9 && <0.10
-    , tasty-quickcheck >= 0.8.4 && < 0.9
-    , containers ==0.5.*
+    , async >=2.1 && <2.3
+    , tasty >= 0.11
+    , tasty-hunit >= 0.9
+    , tasty-quickcheck >= 0.8.4
+    , containers >=0.5 && <0.7
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4
     , proto3-suite

--- a/core/shell.nix
+++ b/core/shell.nix
@@ -1,0 +1,1 @@
+(import ../release.nix).grpc-haskell-core.env

--- a/core/src/Network/GRPC/LowLevel/Call.hs
+++ b/core/src/Network/GRPC/LowLevel/Call.hs
@@ -20,7 +20,7 @@ import           Control.Exception                              (bracket)
 import           Data.ByteString                                (ByteString)
 import           Data.ByteString.Char8                          (pack)
 import           Data.List                                      (intersperse)
-import           Data.Monoid
+import           Data.Semigroup                                 ((<>))
 import           Data.String                                    (IsString)
 import           Foreign.Marshal.Alloc                          (free, malloc)
 import           Foreign.Ptr                                    (Ptr, nullPtr)

--- a/core/src/Network/GRPC/Unsafe/Metadata.chs
+++ b/core/src/Network/GRPC/Unsafe/Metadata.chs
@@ -12,7 +12,7 @@ import Data.Function (on)
 import Data.ByteString (ByteString, useAsCString,
                         useAsCStringLen)
 import Data.List (sortBy, groupBy)
-import Data.Semigroup
+import Data.Semigroup ((<>))
 import qualified Data.SortedList as SL
 import qualified Data.Map.Strict as M
 import Data.Ord (comparing)

--- a/core/src/Network/GRPC/Unsafe/Metadata.chs
+++ b/core/src/Network/GRPC/Unsafe/Metadata.chs
@@ -12,7 +12,7 @@ import Data.Function (on)
 import Data.ByteString (ByteString, useAsCString,
                         useAsCStringLen)
 import Data.List (sortBy, groupBy)
-import Data.Semigroup ((<>))
+import Data.Semigroup (Semigroup((<>)))
 import qualified Data.SortedList as SL
 import qualified Data.Map.Strict as M
 import Data.Ord (comparing)

--- a/core/tests/UnsafeTests.hs
+++ b/core/tests/UnsafeTests.hs
@@ -19,8 +19,8 @@ import           Network.GRPC.Unsafe.Security
 import           Network.GRPC.Unsafe.Slice
 import           Network.GRPC.Unsafe.Time
 import           System.Clock
-import           Test.QuickCheck.Gen             as QC
-import           Test.QuickCheck.Property        as QC
+import           Test.QuickCheck.Gen
+import qualified Test.QuickCheck.Property        as QC
 import           Test.Tasty
 import           Test.Tasty.HUnit                as HU (testCase, (@?=))
 import           Test.Tasty.QuickCheck           as QC

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -53,7 +53,7 @@ executable hellos-server
       base >=4.8 && <5.0
       , async
       , bytestring == 0.10.*
-      , containers ==0.5.*
+      , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core
       , proto3-suite
@@ -73,7 +73,7 @@ executable hellos-client
       base >=4.8 && <5.0
       , async
       , bytestring == 0.10.*
-      , containers ==0.5.*
+      , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core
       , proto3-suite
@@ -93,7 +93,7 @@ executable echo-server
       base >=4.8 && <5.0
       , async
       , bytestring == 0.10.*
-      , containers ==0.5.*
+      , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core
       , optparse-generic
@@ -117,7 +117,7 @@ executable arithmetic-server
       base >=4.8 && <5.0
       , async
       , bytestring == 0.10.*
-      , containers ==0.5.*
+      , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core
       , optparse-generic
@@ -140,7 +140,7 @@ executable arithmetic-client
       base >=4.8 && <5.0
       , async
       , bytestring == 0.10.*
-      , containers ==0.5.*
+      , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core
       , optparse-generic
@@ -163,7 +163,7 @@ executable echo-client
       base >=4.8 && <5.0
       , async
       , bytestring == 0.10.*
-      , containers ==0.5.*
+      , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core
       , optparse-generic
@@ -189,10 +189,10 @@ test-suite tests
     , unix
     , time
     , async
-    , tasty >= 0.11 && <0.12
-    , tasty-hunit >= 0.9 && <0.10
-    , tasty-quickcheck >= 0.8.4 && < 0.9
-    , containers ==0.5.*
+    , tasty >= 0.11
+    , tasty-hunit >= 0.9
+    , tasty-quickcheck >= 0.8.4
+    , containers >=0.5 && <0.7
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4
     , proto3-suite

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).grpc-haskell.env


### PR DESCRIPTION
Note that even though we can now build grpc-haskell and grpc-haskell-core
with modern tasty, the environment in which we built those test programs
did not support actually running all them successfully, due to the need to test
generated code in the context of the appropriate libraries.  We do not yet
know whether test programs built with new versions of tasty would succeed
in the appropriate environment.  In principle this could be discovered, but
the work involved is far from trivial, and therefore we defer it to another
time.  Tests built with the old tasty still work.