### PR TITLE
Fix async exception handling

### DIFF
--- a/core/src/Network/GRPC/LowLevel/Client.hs
+++ b/core/src/Network/GRPC/LowLevel/Client.hs
@@ -11,7 +11,7 @@
 -- `Network.GRPC.LowLevel.Client.Unregistered`.
 module Network.GRPC.LowLevel.Client where
 
-import           Control.Exception                     (bracket, finally)
+import           Control.Exception                     (bracket)
 import           Control.Concurrent.MVar
 import           Control.Monad
 import           Control.Monad.IO.Class
@@ -222,9 +222,12 @@ withClientCallParent :: Client
                      -> (ClientCall -> IO (Either GRPCIOError a))
                      -> IO (Either GRPCIOError a)
 withClientCallParent cl rm tm parent f =
-  clientCreateCallParent cl rm tm parent >>= \case
+  bracket (clientCreateCallParent cl rm tm parent) cleanup $ \case
     Left e  -> return (Left e)
-    Right c -> f c `finally` do
+    Right c -> f c
+  where
+    cleanup (Left _) = pure ()
+    cleanup (Right c) = do
       debugClientCall c
       grpcDebug "withClientCall(R): destroying."
       destroyClientCall c

--- a/core/src/Network/GRPC/LowLevel/Client/Unregistered.hs
+++ b/core/src/Network/GRPC/LowLevel/Client/Unregistered.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns    #-}
 
 module Network.GRPC.LowLevel.Client.Unregistered where
 
 import           Control.Arrow
-import           Control.Exception                                  (finally)
+import           Control.Exception                                  (bracket)
 import           Control.Monad                                      (join)
 import           Data.ByteString                                    (ByteString)
 import           Foreign.Ptr                                        (nullPtr)
@@ -40,13 +41,15 @@ withClientCall :: Client
                -> TimeoutSeconds
                -> (ClientCall -> IO (Either GRPCIOError a))
                -> IO (Either GRPCIOError a)
-withClientCall client method timeout f = do
-  createResult <- clientCreateCall client method timeout
-  case createResult of
+withClientCall client method timeout f =
+  bracket (clientCreateCall client method timeout) cleanup $ \case
     Left x -> return $ Left x
-    Right call -> f call `finally` logDestroy call
-                    where logDestroy c = grpcDebug "withClientCall(U): destroying."
-                                         >> destroyClientCall c
+    Right call -> f call
+  where
+    cleanup (Left _) = pure ()
+    cleanup (Right call) = do
+      grpcDebug "withClientCall(U): destroying."
+      destroyClientCall call
 
 -- | Makes a normal (non-streaming) request without needing to register a method
 -- first. Probably only useful for testing.


### PR DESCRIPTION
Previously, grpc-haskell used a lot of code in the form of

```
do x <- acquireResource
   f x `finally` releaseResource x
```

This is not safe since you can get killed after acquiring the resource
but before installing the exception handler via `finally`. We have
seen various gRPC assertion errors and crashes on shutdown when this
got triggered.