### PR TITLE
Fix sdist tarballs

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -10,6 +10,9 @@ copyright:           Copyright 2016 Awake Networks
 category:            Network
 build-type:          Simple
 cabal-version:       >=1.10
+extra-source-files:  include/grpc_haskell.h
+                     tests/ssl/localhost.crt
+                     tests/ssl/localhost.key
 
 Flag Debug
   Description: Adds debug logging.

--- a/examples/echo/echo-hs/Echo.hs
+++ b/examples/echo/echo-hs/Echo.hs
@@ -116,7 +116,7 @@ instance HsJSONPB.ToSchema EchoRequest where
                                        HsJSONPB._namedSchemaSchema =
                                          Hs.mempty{HsJSONPB._schemaParamSchema =
                                                      Hs.mempty{HsJSONPB._paramSchemaType =
-                                                                 HsJSONPB.SwaggerObject},
+                                                                 Hs.Just HsJSONPB.SwaggerObject},
                                                    HsJSONPB._schemaProperties =
                                                      HsJSONPB.insOrdFromList
                                                        [("message", echoRequestMessage)]}})
@@ -171,7 +171,7 @@ instance HsJSONPB.ToSchema EchoResponse where
                                        HsJSONPB._namedSchemaSchema =
                                          Hs.mempty{HsJSONPB._schemaParamSchema =
                                                      Hs.mempty{HsJSONPB._paramSchemaType =
-                                                                 HsJSONPB.SwaggerObject},
+                                                                 Hs.Just HsJSONPB.SwaggerObject},
                                                    HsJSONPB._schemaProperties =
                                                      HsJSONPB.insOrdFromList
                                                        [("message", echoResponseMessage)]}})

--- a/examples/tutorial/Arithmetic.hs
+++ b/examples/tutorial/Arithmetic.hs
@@ -149,7 +149,7 @@ instance HsJSONPB.ToSchema TwoInts where
                                        HsJSONPB._namedSchemaSchema =
                                          Hs.mempty{HsJSONPB._schemaParamSchema =
                                                      Hs.mempty{HsJSONPB._paramSchemaType =
-                                                                 HsJSONPB.SwaggerObject},
+                                                                 Hs.Just HsJSONPB.SwaggerObject},
                                                    HsJSONPB._schemaProperties =
                                                      HsJSONPB.insOrdFromList
                                                        [("x", twoIntsX), ("y", twoIntsY)]}})
@@ -202,7 +202,7 @@ instance HsJSONPB.ToSchema OneInt where
                                        HsJSONPB._namedSchemaSchema =
                                          Hs.mempty{HsJSONPB._schemaParamSchema =
                                                      Hs.mempty{HsJSONPB._paramSchemaType =
-                                                                 HsJSONPB.SwaggerObject},
+                                                                 Hs.Just HsJSONPB.SwaggerObject},
                                                    HsJSONPB._schemaProperties =
                                                      HsJSONPB.insOrdFromList
                                                        [("result", oneIntResult)]}})

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -10,6 +10,10 @@ copyright:           Copyright 2016 Awake Networks
 category:            Network
 build-type:          Simple
 cabal-version:       >=1.10
+extra-source-files:  tests/*.hs
+                     tests/*.proto
+                     tests/*.py
+                     tests/*.sh
 
 Flag Debug
   Description: Adds debug logging.

--- a/release.nix
+++ b/release.nix
@@ -204,21 +204,21 @@ let
               (haskellPackagesNew.callPackage ./nix/proto3-suite.nix {});
 
           grpc-haskell-core =
-            usesGRPC
+            pkgs.haskell.lib.buildFromSdist (usesGRPC
               (pkgs.haskell.lib.overrideCabal
                 (haskellPackagesNew.callPackage ./core { })
-                (_: { buildDepends = [ haskellPackagesNew.c2hs ]; }));
+                (_: { buildDepends = [ haskellPackagesNew.c2hs ]; })));
 
           grpc-haskell-no-tests =
-            usesGRPC
+            pkgs.haskell.lib.buildFromSdist (usesGRPC
               (pkgs.haskell.lib.dontCheck
                 (haskellPackagesNew.callPackage ./default.nix { })
-              );
+              ));
 
           grpc-haskell =
             usesGRPC
               (pkgs.haskell.lib.overrideCabal
-                (haskellPackagesNew.callPackage ./default.nix { })
+                (pkgs.haskell.lib.buildFromSdist ((haskellPackagesNew.callPackage ./default.nix { })))
                 (oldDerivation:
                   let
                     ghc =


### PR DESCRIPTION
A bunch of files have been missing from the tarballs created by `cabal
sdist`. I’ve changed the nix config to check for this and also found
some examples that I forgot to update in a previous PR (sorry about
that).