### PR TITLE
Make server process killable

### DIFF
--- a/core/src/Network/GRPC/LowLevel/Server/Unregistered.hs
+++ b/core/src/Network/GRPC/LowLevel/Server/Unregistered.hs
@@ -48,7 +48,7 @@ withServerCallAsync :: Server
                     -> (ServerCall -> IO ())
                     -> IO ()
 withServerCallAsync s f = mask $ \unmask ->
-  serverCreateCall s >>= \case
+  unmask (serverCreateCall s) >>= \case
     Left e -> do grpcDebug $ "withServerCallAsync: call error: " ++ show e
                  return ()
     Right c -> do wasForkSuccess <- forkServer s handler


### PR DESCRIPTION
https://github.com/awakesecurity/gRPC-haskell/commit/35163c3c1861f2eb27ea443dac20a4960d76d87d
introduced a new use of `mask` which makes the server process uninterruptible
while waiting for a new incoming request.  This change fixes that by
surrounding the logic that waits for a new request with `unmask`.  This
new `unmask` should still respect the finalization guarantees of the
surrounding masked code.