### PR TITLE
grpc-haskell-0.2.0.0: Upgrade to proto3-wire-1.2.0, proto3-suite-0.4.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ examples/echo/echo-cpp/echo-client
 examples/echo/echo-cpp/echo-server
 benchmarks.html
 result
-
 *~
 cabal.project.local
 dist-newstyle/
+tests/py-tmp
+tests/tmp

--- a/core/src/Network/GRPC/Unsafe/Op.chs
+++ b/core/src/Network/GRPC/Unsafe/Op.chs
@@ -4,7 +4,6 @@ module Network.GRPC.Unsafe.Op where
 
 {#import Network.GRPC.Unsafe.Slice#}
 
-import Control.Exception
 import Foreign.C.Types
 import Foreign.Ptr
 {#import Network.GRPC.Unsafe.ByteBuffer#}

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 }:
 mkDerivation {
   pname = "grpc-haskell";
-  version = "0.0.0.0";
+  version = "0.0.2.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell
-version:             0.0.1.0
+version:             0.0.2.0
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -29,8 +29,8 @@ library
   build-depends:
       base >=4.8 && <5.0
     , bytestring ==0.10.*
-    , proto3-suite >=0.4.0.0
-    , proto3-wire
+    , proto3-suite >=0.4.2.0
+    , proto3-wire >=1.2.0
     , grpc-haskell-core
     , async >=2.1 && <2.3
     , managed >= 1.0.5

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -32,7 +32,6 @@ library
     , proto3-suite >=0.4.0.0
     , proto3-wire
     , grpc-haskell-core
-
     , async >=2.1 && <2.3
     , managed >= 1.0.5
 

--- a/nix/parameterized.patch
+++ b/nix/parameterized.patch
@@ -1,0 +1,44 @@
+diff --git a/test/Parameterized/Control/Monad/Trans/Reader/ReaderSpec.hs b/test/Parameterized/Control/Monad/Trans/Reader/ReaderSpec.hs
+index a39d181..1999e57 100644
+--- a/test/Parameterized/Control/Monad/Trans/Reader/ReaderSpec.hs
++++ b/test/Parameterized/Control/Monad/Trans/Reader/ReaderSpec.hs
+@@ -91,7 +91,7 @@ whichIntBoolStringReader = do
+ manyIntMaybeReader :: ReaderT (Many '[Int]) Maybe String
+ manyIntMaybeReader = do
+     a <- ask
+-    let r = fetch @Int a
++    let r = grab @Int a
+     case r of
+         0 -> empty
+         r' -> pure $ show r'
+@@ -99,7 +99,7 @@ manyIntMaybeReader = do
+ manyBoolMaybeReader :: ReaderT (Many '[Bool]) Maybe String
+ manyBoolMaybeReader = do
+     a <- ask
+-    let r = fetch @Bool a
++    let r = grab @Bool a
+     case r of
+         False -> empty
+         r' -> pure $ show r'
+diff --git a/test/Parameterized/Control/Monad/Trans/State/Strict/StateSpec.hs b/test/Parameterized/Control/Monad/Trans/State/Strict/StateSpec.hs
+index 7dfd46c..4777c13 100644
+--- a/test/Parameterized/Control/Monad/Trans/State/Strict/StateSpec.hs
++++ b/test/Parameterized/Control/Monad/Trans/State/Strict/StateSpec.hs
+@@ -26,7 +26,7 @@ main = hspec spec
+ manyIntMaybeState :: StateT (Many '[Int]) Maybe String
+ manyIntMaybeState= do
+     s <- get
+-    let r = fetch @Int s
++    let r = grab @Int s
+     case r of
+         0 -> empty
+         r' -> do
+@@ -36,7 +36,7 @@ manyIntMaybeState= do
+ manyBoolMaybeState :: StateT (Many '[Bool]) Maybe String
+ manyBoolMaybeState = do
+     s <- get
+-    let r = fetch @Bool s
++    let r = grab @Bool s
+     case r of
+         False -> empty
+         r' -> do

--- a/nix/proto3-suite.nix
+++ b/nix/proto3-suite.nix
@@ -5,17 +5,16 @@
 , insert-ordered-containers, lens, mtl, neat-interpolation
 , optparse-applicative, optparse-generic, parsec, parsers, pretty
 , pretty-show, proto3-wire, QuickCheck, quickcheck-instances
-, range-set-list, safe, semigroups, stdenv, swagger2
-, system-filepath, tasty, tasty-hunit, tasty-quickcheck, text
-, transformers, turtle, vector
+, range-set-list, safe, stdenv, swagger2, system-filepath, tasty
+, tasty-hunit, tasty-quickcheck, text, transformers, turtle, vector
 }:
 mkDerivation {
   pname = "proto3-suite";
-  version = "0.4.0.0";
+  version = "0.4.2.0";
   src = fetchgit {
-    url = "https://github.com/awakesecurity/proto3-suite";
-    sha256 = "0g7j7axx9rkrzw32ky9xl08zj34rx4mqafd89lrpnsi8lcq2z06j";
-    rev = "3f6dd6f612cf2eba3c05798926ff924b0d5ab4fa";
+    url = "https://github.com/awakesecurity/proto3-suite.git";
+    sha256 = "0mpy35r6qd1v5sixhy2lqcn5x81rfj4dc079g1kpa4fb1f23dbha";
+    rev = "0af901f9ef3b9719e08eae4fab8fd700d6c8047a";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -26,8 +25,8 @@ mkDerivation {
     bytestring cereal containers contravariant deepseq filepath foldl
     hashable haskell-src insert-ordered-containers lens mtl
     neat-interpolation parsec parsers pretty pretty-show proto3-wire
-    QuickCheck quickcheck-instances safe semigroups swagger2
-    system-filepath text transformers turtle vector
+    QuickCheck quickcheck-instances safe swagger2 system-filepath text
+    transformers turtle vector
   ];
   executableHaskellDepends = [
     base containers mtl optparse-applicative optparse-generic
@@ -36,8 +35,8 @@ mkDerivation {
   testHaskellDepends = [
     aeson attoparsec base base64-bytestring bytestring cereal
     containers deepseq doctest generic-arbitrary mtl pretty-show
-    proto3-wire QuickCheck semigroups swagger2 tasty tasty-hunit
-    tasty-quickcheck text transformers turtle vector
+    proto3-wire QuickCheck swagger2 tasty tasty-hunit tasty-quickcheck
+    text transformers turtle vector
   ];
   description = "A low level library for writing out data in the Protocol Buffers wire format";
   license = stdenv.lib.licenses.asl20;

--- a/nix/proto3-wire.nix
+++ b/nix/proto3-wire.nix
@@ -1,23 +1,25 @@
 { mkDerivation, base, bytestring, cereal, containers, deepseq
-, doctest, fetchgit, hashable, QuickCheck, safe, stdenv, tasty
-, tasty-hunit, tasty-quickcheck, text, unordered-containers
+, doctest, fetchgit, ghc-prim, hashable, parameterized, primitive
+, QuickCheck, safe, stdenv, tasty, tasty-hunit, tasty-quickcheck
+, text, transformers, unordered-containers, vector
 }:
 mkDerivation {
   pname = "proto3-wire";
-  version = "1.1.0";
+  version = "1.2.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-wire.git";
-    sha256 = "16l1rnnygwk1b2sb3l6klhr6ad0wvry204icxnc81c6rbzbk6rqc";
-    rev = "4f355bbac895d577d8a28f567ab4380f042ccc24";
+    sha256 = "062b05ab8icwjxaqrh3wmg8s26m620pigqj3dj6rdx9qas1cq6mi";
+    rev = "d92ec32ef0f15842b07fb226d8f2d15f36c5fb20";
     fetchSubmodules = true;
   };
   libraryHaskellDepends = [
-    base bytestring cereal containers deepseq hashable QuickCheck safe
-    text unordered-containers
+    base bytestring cereal containers deepseq ghc-prim hashable
+    parameterized primitive QuickCheck safe text transformers
+    unordered-containers vector
   ];
   testHaskellDepends = [
     base bytestring cereal doctest QuickCheck tasty tasty-hunit
-    tasty-quickcheck text
+    tasty-quickcheck text transformers vector
   ];
   description = "A low-level implementation of the Protocol Buffers (version 3) wire format";
   license = stdenv.lib.licenses.asl20;

--- a/release.nix
+++ b/release.nix
@@ -66,10 +66,6 @@ let
   };
 
   overlay = pkgsNew: pkgsOld: {
-    protobuf3_2NoCheck =
-      pkgsNew.stdenv.lib.overrideDerivation
-        pkgsNew.pythonPackages.protobuf
-        (oldAttrs : {doCheck = false; doInstallCheck = false;});
 
     cython = pkgsNew.pythonPackages.buildPythonPackage rec {
       name = "Cython-${version}";
@@ -177,26 +173,6 @@ let
       ];
     };
 
-    usesGRPC = haskellPackage:
-      pkgsNew.haskell.lib.overrideCabal haskellPackage (oldAttributes: {
-          preBuild = (oldAttributes.preBuild or "") +
-            pkgsNew.lib.optionalString pkgsNew.stdenv.isDarwin ''
-              export DYLD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
-            '' +
-            pkgsNew.lib.optionalString pkgsNew.stdenv.isLinux ''
-              export LD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
-            '';
-
-          shellHook = (oldAttributes.shellHook or "") +
-            pkgsNew.lib.optionalString pkgsNew.stdenv.isDarwin ''
-              export DYLD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
-            '' +
-            pkgsNew.lib.optionalString pkgsNew.stdenv.isLinux ''
-              export LD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
-            '';
-        }
-      );
-
     haskellPackages = pkgsOld.haskellPackages.override {
       overrides = haskellPackagesNew: haskellPackagesOld: rec {
 
@@ -286,6 +262,11 @@ let
       };
     };
 
+    protobuf3_2NoCheck =
+      pkgsNew.stdenv.lib.overrideDerivation
+        pkgsNew.pythonPackages.protobuf
+        (oldAttrs : {doCheck = false; doInstallCheck = false;});
+
     test-grpc-haskell =
       pkgsNew.mkShell {
         nativeBuildInputs = [
@@ -296,6 +277,26 @@ let
           )
         ];
       };
+
+    usesGRPC = haskellPackage:
+      pkgsNew.haskell.lib.overrideCabal haskellPackage (oldAttributes: {
+          preBuild = (oldAttributes.preBuild or "") +
+            pkgsNew.lib.optionalString pkgsNew.stdenv.isDarwin ''
+              export DYLD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
+            '' +
+            pkgsNew.lib.optionalString pkgsNew.stdenv.isLinux ''
+              export LD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
+            '';
+
+          shellHook = (oldAttributes.shellHook or "") +
+            pkgsNew.lib.optionalString pkgsNew.stdenv.isDarwin ''
+              export DYLD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
+            '' +
+            pkgsNew.lib.optionalString pkgsNew.stdenv.isLinux ''
+              export LD_LIBRARY_PATH=${pkgsNew.grpc}/lib''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
+            '';
+        }
+      );
   };
 
   overlays = [ overlay ];

--- a/release.nix
+++ b/release.nix
@@ -63,6 +63,9 @@ let
 
   config = {
     allowUnfree = true;
+    # For parameterized-0.5.0.0, which we patch for compatbility with
+    # proto3-wire-1.2.0 (which also uses the same patch)
+    allowBroken = true;
   };
 
   overlay = pkgsNew: pkgsOld: {
@@ -258,6 +261,8 @@ let
                   '';
                 })
             );
+
+        parameterized = pkgsNew.haskell.lib.appendPatch haskellPackagesOld.parameterized ./nix/parameterized.patch;
 
       };
     };

--- a/src/Network/GRPC/HighLevel/Generated.hs
+++ b/src/Network/GRPC/HighLevel/Generated.hs
@@ -42,7 +42,6 @@ import           Network.GRPC.HighLevel.Server
 import           Network.GRPC.HighLevel.Client
 import           Network.GRPC.LowLevel
 import           Network.GRPC.LowLevel.Call
-import qualified Network.GRPC.Unsafe.ChannelArgs as C
 import           Numeric.Natural
 import           System.IO (hPutStrLn, stderr)
 

--- a/src/Network/GRPC/HighLevel/Generated.hs
+++ b/src/Network/GRPC/HighLevel/Generated.hs
@@ -42,6 +42,8 @@ import           Network.GRPC.HighLevel.Server
 import           Network.GRPC.HighLevel.Client
 import           Network.GRPC.LowLevel
 import           Network.GRPC.LowLevel.Call
+import qualified Network.GRPC.Unsafe.ChannelArgs as C
+import           Numeric.Natural
 import           System.IO (hPutStrLn, stderr)
 
 -- | Used at the kind level as a parameter to service definitions
@@ -78,6 +80,8 @@ data ServiceOptions = ServiceOptions
     -- ^ Security configuration.
   , logger               :: String -> IO ()
     -- ^ Logging function to use to log errors in handling calls.
+  , serverMaxReceiveMessageLength :: Maybe Natural
+    -- ^ Maximum length (in bytes) that the service may receive in a single message
   }
 
 defaultServiceOptions :: ServiceOptions
@@ -91,6 +95,7 @@ defaultServiceOptions = ServiceOptions
   , Network.GRPC.HighLevel.Generated.initialMetadata = mempty
   , Network.GRPC.HighLevel.Generated.sslConfig       = Nothing
   , Network.GRPC.HighLevel.Generated.logger          = hPutStrLn stderr
+  , Network.GRPC.HighLevel.Generated.serverMaxReceiveMessageLength = Nothing
   }
 
 withGRPCClient :: ClientConfig -> (Client -> IO a) -> IO a

--- a/src/Network/GRPC/HighLevel/Server.hs
+++ b/src/Network/GRPC/HighLevel/Server.hs
@@ -13,6 +13,7 @@ import           Control.Monad
 import           Data.ByteString                           (ByteString)
 import qualified Data.ByteString.Lazy                      as BL
 import           Network.GRPC.LowLevel
+import           Numeric.Natural
 import           Proto3.Suite.Class
 import           System.IO
 
@@ -225,6 +226,7 @@ data ServerOptions = ServerOptions
     -- ^ Security configuration.
   , optLogger               :: String -> IO ()
     -- ^ Logging function to use to log errors in handling calls.
+  , optMaxReceiveMessageLength :: Maybe Natural
   }
 
 defaultOptions :: ServerOptions
@@ -241,6 +243,7 @@ defaultOptions = ServerOptions
   , optInitialMetadata      = mempty
   , optSSLConfig            = Nothing
   , optLogger               = hPutStrLn stderr
+  , optMaxReceiveMessageLength = Nothing
   }
 
 serverLoop :: ServerOptions -> IO ()

--- a/src/Network/GRPC/HighLevel/Server/Unregistered.hs
+++ b/src/Network/GRPC/HighLevel/Server/Unregistered.hs
@@ -122,5 +122,7 @@ serverLoop ServerOptions{..} =
           [ UserAgentPrefix optUserAgentPrefix
           , UserAgentSuffix optUserAgentSuffix
           ]
+          ++
+          foldMap (pure . MaxReceiveMessageLength) optMaxReceiveMessageLength
       , sslConfig = optSSLConfig
       }


### PR DESCRIPTION
- Upgrade to `proto3-wire-1.2.0`
- Upgrade to `proto3-suite-0.4.2.0`
- Expose max receive message length channel arg in `ServiceOptions` (0deefd4bc68e7bdf2bc9f28a2b44656b7f0431d3)