### PR TITLE
Version 0.1.0

### DIFF
--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell
-version:             0.0.2.0
+version:             0.1.0
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0


### PR DESCRIPTION
This is to prepare for an upcoming release to Hackage.  I increased the
version to 0.1.0 to reflect what I believe is a breaking change in #117
(since `grpc-haskell` will now require a newer version of the C `grpc`
dependency).