### PR TITLE
Add 1 to malloc'd buffer size for null terminator

### DIFF
--- a/core/cbits/grpc_haskell.c
+++ b/core/cbits/grpc_haskell.c
@@ -427,7 +427,7 @@ void create_string_arg(grpc_arg* args, size_t i,
   grpc_arg* arg = args+i;
   arg->type = GRPC_ARG_STRING;
   arg->key = translate_arg_key(key);
-  char* storeValue = malloc(sizeof(char)*strlen(value));
+  char* storeValue = malloc(sizeof(char)*(strlen(value)+1));
   arg->value.string = strcpy(storeValue, value);
 }
 


### PR DESCRIPTION
`strlen` returns the index of the null terminator of the string, so `malloc`ing that many bytes will be 1 less than needed to copy the string. The subsequent `strcpy` will overflow the buffer when copying the null terminator.

Unfortunately, I am still unable to run the package test suite to truly verify this change, but it does now compile for me without the nebulous `gcc` warnings.