### PR TITLE
Update/fix primary `nix-shell` entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Running: cabal configure --extra-include-dirs ... --extra-lib-dirs ... --enable-
 ```
 
 Note that `cabal configure` is run automatically upon `nix-shell` entry so that
-the build can reference include and library paths for the `grpc` library.
+the build can reference include and library paths for the `grpc` and `gpr`
+libraries.
 
 Using the Library
 -----------------

--- a/README.md
+++ b/README.md
@@ -24,15 +24,8 @@ testing:
 
 ```bash
 $ nix-shell
-...
-Running: cabal configure --extra-include-dirs ... --extra-lib-dirs ... --enable-tests
-...
-[nix-shell]$ cabal build && cabal test
+[nix-shell]$ cabal configure --enable-tests && cabal build && cabal test
 ```
-
-Note that `cabal configure` is run automatically upon `nix-shell` entry so that
-the build can reference include and library paths for the `grpc` and `gpr`
-libraries.
 
 Using the Library
 -----------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ have extended and released under the same [`LICENSE`](./LICENSE)
 Installation
 ------------
 
-**The current version of this library requires gRPC version 1.2.0. Newer versions may work but have not been tested.**
+**The current version of this library requires gRPC version 1.34.1. Newer versions may work, but have not been tested.**
 
 Usage
 -----
@@ -24,8 +24,14 @@ testing:
 
 ```bash
 $ nix-shell
-[nix-shell]$ cabal configure --enable-tests && cabal build && cabal test
+...
+Running: cabal configure --extra-include-dirs ... --extra-lib-dirs ... --enable-tests
+...
+[nix-shell]$ cabal build && cabal test
 ```
+
+Note that `cabal configure` is run automatically upon `nix-shell` entry so that
+the build can reference include and library paths for the `grpc` library.
 
 Using the Library
 -----------------

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -68,7 +68,7 @@ library
     , grpc/slice.h
   build-tools:          c2hs
   default-language:     Haskell2010
-  ghc-options:          -Wall -fwarn-incomplete-patterns -fno-warn-unused-do-bind
+  ghc-options:          -Wall -Werror -fwarn-incomplete-patterns -fno-warn-unused-do-bind
   include-dirs:         include
   hs-source-dirs:       src
   default-extensions:   CPP
@@ -103,7 +103,7 @@ test-suite tests
     LowLevelTests.Op,
     UnsafeTests
   default-language:     Haskell2010
-  ghc-options:          -Wall -fwarn-incomplete-patterns -fno-warn-unused-do-bind -g -threaded -rtsopts
+  ghc-options:          -Wall -Werror -fwarn-incomplete-patterns -fno-warn-unused-do-bind -g -threaded -rtsopts
   hs-source-dirs:       tests
   main-is:              Properties.hs
   type:                 exitcode-stdio-1.0

--- a/core/src/Network/GRPC/LowLevel/Call.hs
+++ b/core/src/Network/GRPC/LowLevel/Call.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -212,8 +212,8 @@ destroyClientCall cc = do
   C.grpcCallUnref (unsafeCC cc)
 
 destroyServerCall :: ServerCall a -> IO ()
-destroyServerCall sc@ServerCall{ unsafeSC = c, .. } = do
+destroyServerCall sc@ServerCall{ unsafeSC } = do
   grpcDebug "destroyServerCall(R): entered."
   debugServerCall sc
-  grpcDebug $ "Destroying server-side call object: " ++ show c
-  C.grpcCallUnref c
+  grpcDebug $ "Destroying server-side call object: " ++ show unsafeSC
+  C.grpcCallUnref unsafeSC

--- a/core/src/Network/GRPC/LowLevel/CompletionQueue.hs
+++ b/core/src/Network/GRPC/LowLevel/CompletionQueue.hs
@@ -71,7 +71,7 @@ createCompletionQueue _ = do
 -- Throws 'CallError' if 'grpcCallStartBatch' returns a non-OK code.
 startBatch :: CompletionQueue -> C.Call -> C.OpArray -> Int -> C.Tag
               -> IO (Either GRPCIOError ())
-startBatch cq@CompletionQueue{..} call opArray opArraySize tag =
+startBatch cq call opArray opArraySize tag =
     withPermission Push cq $ fmap throwIfCallError $ do
       grpcDebug $ "startBatch: calling grpc_call_start_batch with pointers: "
                   ++ show call ++ " " ++ show opArray

--- a/core/src/Network/GRPC/LowLevel/CompletionQueue/Internal.hs
+++ b/core/src/Network/GRPC/LowLevel/CompletionQueue/Internal.hs
@@ -104,7 +104,7 @@ withPermission op cq act = bracket acquire release $ \gotResource ->
 -- 'serverRequestCall', this will block forever unless a timeout is given.
 pluck :: CompletionQueue -> C.Tag -> Maybe TimeoutSeconds
          -> IO (Either GRPCIOError ())
-pluck cq@CompletionQueue{..} tag mwait = do
+pluck cq tag mwait = do
   grpcDebug $ "pluck: called with tag=" ++ show tag ++ ",mwait=" ++ show mwait
   withPermission Pluck cq $ pluck' cq tag mwait
 

--- a/core/src/Network/GRPC/Unsafe.chs
+++ b/core/src/Network/GRPC/Unsafe.chs
@@ -7,7 +7,6 @@ import Control.Exception (bracket)
 import Control.Monad
 
 import Data.ByteString (ByteString, useAsCString)
-import Data.Semigroup (Semigroup)
 
 import Foreign.C.String (CString, peekCString)
 import Foreign.Marshal.Alloc (free)

--- a/core/src/Network/GRPC/Unsafe/Metadata.chs
+++ b/core/src/Network/GRPC/Unsafe/Metadata.chs
@@ -12,7 +12,6 @@ import Data.Function (on)
 import Data.ByteString (ByteString, useAsCString,
                         useAsCStringLen)
 import Data.List (sortBy, groupBy)
-import Data.Semigroup (Semigroup((<>)))
 import qualified Data.SortedList as SL
 import qualified Data.Map.Strict as M
 import Data.Ord (comparing)

--- a/core/tests/LowLevelTests.hs
+++ b/core/tests/LowLevelTests.hs
@@ -22,7 +22,6 @@ import           Data.List                                 (find)
 import qualified Data.Map.Strict                           as M
 import qualified Data.Set                                  as S
 import           GHC.Exts                                  (fromList, toList)
-import           Network.GRPC.Unsafe.ChannelArgs           (Arg(..))
 import           Network.GRPC.LowLevel
 import qualified Network.GRPC.LowLevel.Call.Unregistered   as U
 import qualified Network.GRPC.LowLevel.Client.Unregistered as U
@@ -183,7 +182,7 @@ testSSL =
                                         Nothing)
                   }
     server = TestServer serverConf' $ \s -> do
-      r <- U.serverHandleNormalCall s mempty $ \U.ServerCall{..} body -> do
+      r <- U.serverHandleNormalCall s mempty $ \U.ServerCall{} body -> do
         body @?= "hi"
         return ("reply test", mempty, StatusOk, "")
       r @?= Right ()
@@ -282,7 +281,7 @@ testAuthMetadataTransfer =
                                         serverProcessor)
                   }
     server = TestServer serverConf' $ \s -> do
-      r <- U.serverHandleNormalCall s mempty $ \U.ServerCall{..} body -> do
+      r <- U.serverHandleNormalCall s mempty $ \U.ServerCall{} body -> do
         body @?= "hi"
         return ("reply test", mempty, StatusOk, "")
       r @?= Right ()

--- a/core/tests/LowLevelTests/Op.hs
+++ b/core/tests/LowLevelTests/Op.hs
@@ -27,7 +27,7 @@ testCancelFromServer =
   testCase "Client/Server - client receives server cancellation" $
     runSerialTest $ \grpc ->
       withClientServerUnaryCall grpc $
-        \(Client {..}, Server {..}, ClientCall {..}, sc@ServerCall {..}) -> do
+        \(Client {..}, Server {}, ClientCall {..}, sc@ServerCall {}) -> do
           serverCallCancel sc StatusPermissionDenied "TestStatus"
           clientRes <- runOps unsafeCC clientCQ clientRecvOps
           case clientRes of

--- a/core/tests/UnsafeTests.hs
+++ b/core/tests/UnsafeTests.hs
@@ -20,7 +20,6 @@ import           Network.GRPC.Unsafe.Slice
 import           Network.GRPC.Unsafe.Time
 import           System.Clock
 import           Test.QuickCheck.Gen
-import qualified Test.QuickCheck.Property        as QC
 import           Test.Tasty
 import           Test.Tasty.HUnit                as HU (testCase, (@?=))
 import           Test.Tasty.QuickCheck           as QC

--- a/examples/echo/echo-hs/EchoClient.hs
+++ b/examples/echo/echo-hs/EchoClient.hs
@@ -12,7 +12,6 @@ import           Data.ByteString                  (ByteString)
 import           Data.Maybe                       (fromMaybe)
 import qualified Data.Text.Lazy                   as TL
 import           Echo
-import           GHC.Generics                     (Generic)
 import           Network.GRPC.HighLevel.Client
 import           Network.GRPC.LowLevel
 import           Options.Generic

--- a/examples/echo/echo-hs/EchoServer.hs
+++ b/examples/echo/echo-hs/EchoServer.hs
@@ -9,7 +9,6 @@
 
 import           Data.ByteString                  (ByteString)
 import           Data.Maybe                       (fromMaybe)
-import           GHC.Generics                     (Generic)
 import           Network.GRPC.HighLevel.Generated (GRPCMethodType (..),
                                                    Host (..), Port (..),
                                                    ServerRequest (..),

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -42,7 +42,7 @@ library
     Network.GRPC.HighLevel.Server.Unregistered
     Network.GRPC.HighLevel.Client
   default-language:     Haskell2010
-  ghc-options:          -Wall -fwarn-incomplete-patterns -fno-warn-unused-do-bind
+  ghc-options:          -Wall -Werror -fwarn-incomplete-patterns -fno-warn-unused-do-bind
   hs-source-dirs:       src
   default-extensions:   CPP
   CC-Options: -std=c99
@@ -66,7 +66,7 @@ executable hellos-server
   else
     buildable: False
   default-language: Haskell2010
-  ghc-options:      -Wall -g -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:      -Wall -Werror -g -threaded -rtsopts -with-rtsopts=-N -O2
   hs-source-dirs:   examples/hellos/hellos-server
   main-is:          Main.hs
 
@@ -86,7 +86,7 @@ executable hellos-client
   else
     buildable: False
   default-language: Haskell2010
-  ghc-options:      -Wall -g -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:      -Wall -Werror -g -threaded -rtsopts -with-rtsopts=-N -O2
   hs-source-dirs:   examples/hellos/hellos-client
   main-is:          Main.hs
 
@@ -110,7 +110,7 @@ executable echo-server
   else
     buildable: False
   default-language: Haskell2010
-  ghc-options:      -Wall -g -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:      -Wall -Werror -g -threaded -rtsopts -with-rtsopts=-N -O2
   hs-source-dirs:   examples/echo/echo-hs
   main-is:          EchoServer.hs
 
@@ -135,7 +135,7 @@ executable arithmetic-server
   else
     buildable: False
   default-language: Haskell2010
-  ghc-options:      -Wall -g -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:      -Wall -Werror -g -threaded -rtsopts -with-rtsopts=-N -O2
   hs-source-dirs:   examples/tutorial/
   main-is:          ArithmeticServer.hs
 
@@ -159,7 +159,7 @@ executable arithmetic-client
   else
     buildable: False
   default-language: Haskell2010
-  ghc-options:      -Wall -g -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:      -Wall -Werror -g -threaded -rtsopts -with-rtsopts=-N -O2
   hs-source-dirs:   examples/tutorial/
   main-is:          ArithmeticClient.hs
 
@@ -184,7 +184,7 @@ executable echo-client
   else
     buildable: False
   default-language: Haskell2010
-  ghc-options:      -Wall -g -threaded -rtsopts -with-rtsopts=-N -O2
+  ghc-options:      -Wall -Werror -g -threaded -rtsopts -with-rtsopts=-N -O2
   hs-source-dirs:   examples/echo/echo-hs
   main-is:          EchoClient.hs
 
@@ -211,7 +211,7 @@ test-suite tests
   other-modules:
     GeneratedTests
   default-language:     Haskell2010
-  ghc-options:          -Wall -fwarn-incomplete-patterns -fno-warn-unused-do-bind -g -threaded -rtsopts
+  ghc-options:          -Wall -Werror -fwarn-incomplete-patterns -fno-warn-unused-do-bind -g -threaded -rtsopts
   hs-source-dirs:       tests
   main-is:              Properties.hs
   type:                 exitcode-stdio-1.0
@@ -232,7 +232,7 @@ benchmark bench
     , random >=1.0.0
   hs-source-dirs: bench
   main-is: Bench.hs
-  ghc-options:      -Wall -O2 -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:      -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N
   if flag(debug)
     CPP-Options: -DDEBUG
     CC-Options:  -DGRPC_HASKELL_DEBUG

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -191,7 +191,6 @@ executable echo-client
 test-suite tests
   build-depends:
       base >=4.8 && <5.0
-    , grpc-haskell
     , bytestring ==0.10.*
     , unix
     , time

--- a/release.nix
+++ b/release.nix
@@ -115,16 +115,9 @@ let
                   ghc =
                     haskellPackagesNew.ghcWithPackages (pkgs: [
                       pkgs.grpc-haskell-no-tests
-                      # Include some additional packages in this custom ghc for
-                      # running tests in the nix-shell environment.
-                      pkgs.tasty-quickcheck
-                      pkgs.turtle
                     ]);
-
-                  python = pkgsNew.python.withPackages (pkgs: [
-                    # pkgs.protobuf3_0
-                    pkgs.grpcio-tools
-                  ]);
+                  python =
+                    pkgsNew.python.withPackages (pkgs: [ pkgs.grpcio-tools ]);
 
                 in rec {
                   configureFlags = (oldDerivation.configureFlags or []) ++ [
@@ -167,7 +160,8 @@ let
                     # This lets us use our custom ghc and python environments in the shell.
                     export PATH=${ghc}/bin:${python}/bin''${PATH:+:}$PATH
                   '';
-                })
+                }
+            )
             );
 
         parameterized = pkgsNew.haskell.lib.appendPatch haskellPackagesOld.parameterized ./nix/parameterized.patch;

--- a/release.nix
+++ b/release.nix
@@ -94,9 +94,11 @@ let
 
         grpc-haskell-core =
           pkgsNew.haskell.lib.buildFromSdist (pkgsNew.usesGRPC
-            (pkgsNew.haskell.lib.overrideCabal
-              (haskellPackagesNew.callPackage ./core { })
-              (_: { buildDepends = [ haskellPackagesNew.c2hs ]; })));
+            (haskellPackagesNew.callCabal2nix "grpc-haskell-core" ./core {
+                 gpr = pkgsNew.grpc;
+               }
+            )
+          );
 
         grpc-haskell-no-tests =
           pkgsNew.haskell.lib.buildFromSdist (pkgsNew.usesGRPC

--- a/release.nix
+++ b/release.nix
@@ -126,12 +126,6 @@ let
 
                   buildDepends = [
                     pkgsNew.makeWrapper
-                    # Give our nix-shell its own cabal so we don't pick up one
-                    # from the user's environment by accident.
-                    haskellPackagesNew.cabal-install
-
-                    # And likewise for c2hs
-                    haskellPackagesNew.c2hs
                   ];
 
                   patches = [ tests/tests.patch ];
@@ -186,7 +180,6 @@ let
         nativeBuildInputs = [
           (with pkgsNew.haskellPackages; [
              cabal-install
-             c2hs
              (ghcWithPackages (pkgs: with pkgs; [
                 grpc-haskell-core
                 # No need to guard nix-shell entry on passing package tests

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./release.nix).grpc-haskell.env
+(import ./release.nix).test-grpc-haskell

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./release.nix).test-grpc-haskell
+(import ./release.nix).grpc-haskell.env


### PR DESCRIPTION
Prior to this PR, `nix-shell` was entering via the `grpc-haskell.env` attribute, and the environment it provided was not sufficient to build both `grpc-haskell-core` and `grpc-haskell` (with tests enabled) conveniently.

After this PR, the default entry point is the `test-grpc-haskell` attribute, which has been extended (albeit in somewhat of an adhoc fashion; feedback welcome and appreciated) to support a working development/testing workflow. 

I've also made some miscellaneous cleanups, fixed warnings, etc. Commits are mostly atomic and can be reviewed in order.