### PR TITLE
grpc-haskell{-core} -> 0.2.0: Fix MetadataMap duplicate-key ordering

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -28,7 +28,6 @@ library
     , containers >=0.5 && <0.7
     , managed >= 1.0.0 && < 1.1
     , transformers
-    , sorted-list >=0.1.6.1 && <=0.3
 
   c-sources:
     cbits/grpc_haskell.c

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell-core
-version:             0.1.0
+version:             0.2.0
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -49,6 +49,7 @@ library
     Network.GRPC.LowLevel.CompletionQueue.Internal
     Network.GRPC.LowLevel.CompletionQueue.Unregistered
     Network.GRPC.LowLevel.GRPC
+    Network.GRPC.LowLevel.GRPC.MetadataMap
     Network.GRPC.LowLevel.Op
     Network.GRPC.LowLevel.Server
     Network.GRPC.LowLevel.Call

--- a/core/src/Network/GRPC/LowLevel/GRPC.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC.hs
@@ -11,16 +11,16 @@ GRPC
 , grpcDebug
 , grpcDebug'
 , threadDelaySecs
-, C.MetadataMap(..)
+, MetadataMap(..)
 , C.StatusDetails(..)
 ) where
 
 import           Control.Concurrent     (threadDelay, myThreadId)
 import           Control.Exception
 import           Data.Typeable
+import           Network.GRPC.LowLevel.GRPC.MetadataMap (MetadataMap(..))
 import qualified Network.GRPC.Unsafe    as C
 import qualified Network.GRPC.Unsafe.Op as C
-import qualified Network.GRPC.Unsafe.Metadata as C
 
 -- | Functions as a proof that the gRPC core has been started. The gRPC core
 -- must be initialized to create any gRPC state, so this is a requirement for

--- a/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Network.GRPC.LowLevel.GRPC.MetadataMap where
+
+import Data.ByteString (ByteString)
+import Data.Function (on)
+import GHC.Exts (IsList(..))
+import Data.List (sortBy, groupBy)
+import Data.Ord (comparing)
+import qualified Data.Map.Strict as M
+
+-- | Represents metadata for a given RPC, consisting of key-value pairs. Keys
+-- are allowed to be repeated, with the `last` element of value list usually
+-- taken as the final value for that key. Since repeated keys are unlikely in
+-- practice, the 'IsList' instance uses key-value pairs as items. For example,
+-- @fromList [("key1","val1"),("key2","val2"),("key1","val3")]@.
+newtype MetadataMap = MetadataMap {unMap :: M.Map ByteString [ByteString]}
+  deriving Eq
+
+instance Show MetadataMap where
+  show m = "fromList " ++ show (M.toList (unMap m))
+
+instance Semigroup MetadataMap where
+  MetadataMap m1 <> MetadataMap m2 =
+    MetadataMap $ M.unionWith (<>) m1 m2
+
+instance Monoid MetadataMap where
+  mempty = MetadataMap M.empty
+
+instance IsList MetadataMap where
+  type Item MetadataMap = (ByteString, ByteString)
+  fromList = MetadataMap
+             . M.fromList
+             . map (\xs -> ((fst . head) xs, map snd xs))
+             . groupBy ((==) `on` fst)
+             . sortBy (comparing fst)
+  toList = concatMap (\(k,vs) -> map (k,) vs)
+           . map (fmap toList)
+           . M.toList
+           . unMap

--- a/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
@@ -8,13 +8,27 @@ import Data.Function (on)
 import GHC.Exts (IsList(..))
 import Data.List (sortBy, groupBy)
 import Data.Ord (comparing)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 
--- | Represents metadata for a given RPC, consisting of key-value pairs. Keys
--- are allowed to be repeated, with the `last` element of value list usually
--- taken as the final value for that key. Since repeated keys are unlikely in
--- practice, the 'IsList' instance uses key-value pairs as items. For example,
--- @fromList [("key1","val1"),("key2","val2"),("key1","val3")]@.
+{- | Represents metadata for a given RPC, consisting of key-value pairs (often
+   referred to as "GRPC custom metadata headers").
+
+   Keys are allowed to be repeated, with the 'last' value element (i.e., the
+   last-presented) usually taken as the value for that key (see 'lookupLast' and
+   'lookupAll').
+
+   Since repeated keys are unlikely in practice, the 'IsList' instance for
+   'MetadataMap' uses key-value pairs as items, and treats duplicates
+   appropriately.
+
+   >>> lookupAll "k1" (fromList [("k1","x"), ("k2", "z"), ("k1", "y")])
+   Just ("x" :| ["y"])
+
+   >>> lookupLast "k1" (fromList [("k1","x"), ("k2", "z"), ("k1", "y")])
+   Just "y"
+-}
+
 newtype MetadataMap = MetadataMap {unMap :: M.Map ByteString [ByteString]}
   deriving Eq
 
@@ -39,3 +53,11 @@ instance IsList MetadataMap where
            . map (fmap toList)
            . M.toList
            . unMap
+
+-- | Obtain all header values for a given header key, in presentation order.
+lookupAll :: ByteString -> MetadataMap -> Maybe (NE.NonEmpty ByteString)
+lookupAll k (MetadataMap md) = NE.nonEmpty =<< M.lookup k md
+
+-- | Obtain the last-presented header value for a given header key.
+lookupLast :: ByteString -> MetadataMap -> Maybe ByteString
+lookupLast k = fmap NE.last . lookupAll k

--- a/core/src/Network/GRPC/Unsafe/Metadata.chs
+++ b/core/src/Network/GRPC/Unsafe/Metadata.chs
@@ -1,6 +1,4 @@
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TupleSections      #-}
-{-# LANGUAGE TypeFamilies       #-}
 
 module Network.GRPC.Unsafe.Metadata where
 
@@ -8,52 +6,17 @@ module Network.GRPC.Unsafe.Metadata where
 
 import Control.Exception
 import Control.Monad
-import Data.Function (on)
-import Data.ByteString (ByteString, useAsCString,
-                        useAsCStringLen)
-import Data.List (sortBy, groupBy)
-import qualified Data.Map.Strict as M
-import Data.Ord (comparing)
+import Data.ByteString (ByteString, useAsCString, useAsCStringLen)
 import Foreign.C.String
 import Foreign.Ptr
 import Foreign.Storable
 import GHC.Exts
+import Network.GRPC.LowLevel.GRPC.MetadataMap (MetadataMap)
 
 #include <grpc/grpc.h>
 #include <grpc/status.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc_haskell.h>
-
--- | Represents metadata for a given RPC, consisting of key-value pairs. Keys
--- are allowed to be repeated, with the `last` element of value list usually
--- taken as the final value for that key. Since repeated keys are unlikely in
--- practice, the 'IsList' instance uses key-value pairs as items. For example,
--- @fromList [("key1","val1"),("key2","val2"),("key1","val3")]@.
-
-newtype MetadataMap = MetadataMap {unMap :: M.Map ByteString [ByteString]}
-  deriving Eq
-
-instance Show MetadataMap where
-  show m = "fromList " ++ show (M.toList (unMap m))
-
-instance Semigroup MetadataMap where
-  MetadataMap m1 <> MetadataMap m2 =
-    MetadataMap $ M.unionWith (<>) m1 m2
-
-instance Monoid MetadataMap where
-  mempty = MetadataMap M.empty
-
-instance IsList MetadataMap where
-  type Item MetadataMap = (ByteString, ByteString)
-  fromList = MetadataMap
-             . M.fromList
-             . map (\xs -> ((fst . head) xs, map snd xs))
-             . groupBy ((==) `on` fst)
-             . sortBy (comparing fst)
-  toList = concatMap (\(k,vs) -> map (k,) vs)
-           . map (fmap toList)
-           . M.toList
-           . unMap
 
 -- | Represents a pointer to one or more metadata key/value pairs. This type
 -- is intended to be used when sending metadata.

--- a/core/src/Network/GRPC/Unsafe/Security.chs
+++ b/core/src/Network/GRPC/Unsafe/Security.chs
@@ -13,6 +13,7 @@ import Foreign.C.Types
 import Foreign.Storable
 import Foreign.Marshal.Alloc (free)
 import Foreign.Ptr (nullPtr, FunPtr, Ptr, castPtr)
+import Network.GRPC.LowLevel.GRPC.MetadataMap (MetadataMap)
 
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>

--- a/core/tests/UnsafeTests.hs
+++ b/core/tests/UnsafeTests.hs
@@ -105,7 +105,7 @@ roundtripSliceQC = QC.testProperty "Slice roundtrip: QuickCheck" $
 roundtripSliceUnit :: B.ByteString -> TestTree
 roundtripSliceUnit bs = testCase "ByteString slice roundtrip" $ do
   unslice <- roundtripSlice bs
-  unslice HU.@?= bs
+  unslice @?= bs
 
 roundtripByteBuffer :: B.ByteString -> IO B.ByteString
 roundtripByteBuffer bs = do
@@ -128,7 +128,7 @@ roundtripByteBufferQC = QC.testProperty "ByteBuffer roundtrip: QuickCheck" $
 roundtripByteBufferUnit :: B.ByteString -> TestTree
 roundtripByteBufferUnit bs = testCase "ByteBuffer roundtrip" $ do
   bs' <- roundtripByteBuffer bs
-  bs' HU.@?= bs
+  bs' @?= bs
 
 roundtripTimeSpec :: TimeSpec -> TestTree
 roundtripTimeSpec t = testCase "CTimeSpec roundtrip" $ do
@@ -151,12 +151,12 @@ testMetadata = testCase "Metadata setter/getter roundtrip" $ do
   v1 <- getMetadataVal m 1
   k2 <- getMetadataKey m 2
   v2 <- getMetadataVal m 2
-  k0 HU.@?= "hello"
-  v0 HU.@?= "world"
-  k1 HU.@?= "foo"
-  v1 HU.@?= "bar"
-  k2 HU.@?= "Haskell"
-  v2 HU.@?= "Curry"
+  k0 @?= "hello"
+  v0 @?= "world"
+  k1 @?= "foo"
+  v1 @?= "bar"
+  k2 @?= "Haskell"
+  v2 @?= "Curry"
   metadataFree m
 
 testMetadataOrdering :: TestTree
@@ -165,11 +165,11 @@ testMetadataOrdering = testCase "Metadata map ordering (simple)" $ do
   let m1 = fromList @MetadataMap [("foo", "baz")]
   let lr = m0 <> m1
   let rl = m1 <> m0
-  M.lookup "foo" (unMap lr) HU.@?= Just ["bar", "baz"]
-  M.lookup "foo" (unMap rl) HU.@?= Just ["baz", "bar"]
-  toList lr HU.@?= [("fnord", "FNORD"), ("foo", "bar"), ("foo", "baz")]
-  toList rl HU.@?= [("fnord", "FNORD"), ("foo", "baz"), ("foo", "bar")]
-  M.lookup "foo" (unMap (lr <> rl)) HU.@?= Just ["bar", "baz", "baz", "bar"]
+  M.lookup "foo" (unMap lr) @?= Just (["bar", "baz"])
+  M.lookup "foo" (unMap rl) @?= Just (["baz", "bar"])
+  toList lr @?= [("fnord", "FNORD"), ("foo", "bar"), ("foo", "baz")]
+  toList rl @?= [("fnord", "FNORD"), ("foo", "baz"), ("foo", "bar")]
+  M.lookup "foo" (unMap (lr <> rl)) @?= Just (["bar", "baz", "baz", "bar"])
 
 testMetadataOrderingProp :: TestTree
 testMetadataOrderingProp = testCase "Metadata map ordering prop w/ trivial inputs" $
@@ -185,10 +185,10 @@ checkMetadataOrdering md0 = do
   m <- metadataAlloc n
   let deref i = (,) <$> getMetadataKey m i <*> getMetadataVal m i
   mapM_ (\((k, v), i) -> setMetadataKeyVal k v m i) ikvps
-  mapM_ (\(kvp, i) -> deref i >>= (HU.@?= kvp)) ikvps
+  mapM_ (\(kvp, i) -> deref i >>= (@?= kvp)) ikvps
   md1 <- getAllMetadata m n
-  unMap md1 HU.@?= M.unionsWith (<>) [M.singleton k [v] | ((k, v), _i) <- ikvps]
-  md1 HU.@?= md0
+  unMap md1 @?= M.unionsWith (<>) [M.singleton k [v] | ((k, v), _i) <- ikvps]
+  md1 @?= md0
   metadataFree m
 
 currTimeMillis :: ClockType -> IO Int
@@ -236,8 +236,8 @@ testCreateDestroyServerCreds = testCase "Create/destroy server credentials" $
 
 assertCqEventComplete :: Event -> IO ()
 assertCqEventComplete e = do
-  eventCompletionType e HU.@?= OpComplete
-  eventSuccess e HU.@?= True
+  eventCompletionType e @?= OpComplete
+  eventSuccess e @?= True
 
 grpc :: IO a -> IO ()
 grpc = bracket_ grpcInit grpcShutdownBlocking . void

--- a/core/tests/UnsafeTests.hs
+++ b/core/tests/UnsafeTests.hs
@@ -156,11 +156,11 @@ testMetadataOrdering = testCase "Metadata map ordering (simple)" $ do
   let m1 = fromList @MetadataMap [("foo", "baz")]
   let lr = m0 <> m1
   let rl = m1 <> m0
-  M.lookup "foo" (unMap lr) HU.@?= Just (fromList ["bar", "baz"])
-  M.lookup "foo" (unMap rl) HU.@?= Just (fromList ["baz", "bar"])
+  M.lookup "foo" (unMap lr) HU.@?= Just ["bar", "baz"]
+  M.lookup "foo" (unMap rl) HU.@?= Just ["baz", "bar"]
   toList lr HU.@?= [("fnord", "FNORD"), ("foo", "bar"), ("foo", "baz")]
   toList rl HU.@?= [("fnord", "FNORD"), ("foo", "baz"), ("foo", "bar")]
-  M.lookup "foo" (unMap (lr <> rl)) HU.@?= Just (fromList ["bar", "baz", "baz", "bar"])
+  M.lookup "foo" (unMap (lr <> rl)) HU.@?= Just ["bar", "baz", "baz", "bar"]
 
 currTimeMillis :: ClockType -> IO Int
 currTimeMillis t = do

--- a/core/tests/UnsafeTests.hs
+++ b/core/tests/UnsafeTests.hs
@@ -12,7 +12,7 @@ import qualified Data.Map                        as M
 import           Foreign.Marshal.Alloc
 import           Foreign.Storable
 import           GHC.Exts
-import           Network.GRPC.LowLevel.GRPC      (threadDelaySecs)
+import           Network.GRPC.LowLevel.GRPC      (MetadataMap(..), threadDelaySecs)
 import           Network.GRPC.Unsafe
 import           Network.GRPC.Unsafe.ByteBuffer
 import           Network.GRPC.Unsafe.ChannelArgs

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell
-version:             0.1.0
+version:             0.2.0
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0
@@ -31,7 +31,7 @@ library
     , bytestring ==0.10.*
     , proto3-suite >=0.4.1
     , proto3-wire >=1.2.0
-    , grpc-haskell-core
+    , grpc-haskell-core >=0.2.0
     , async >=2.1 && <2.3
     , managed >= 1.0.5
 
@@ -58,7 +58,7 @@ executable hellos-server
       , bytestring == 0.10.*
       , containers >=0.5 && <0.7
       , grpc-haskell
-      , grpc-haskell-core
+      , grpc-haskell-core >=0.2.0
       , proto3-suite
       , proto3-wire
       , text
@@ -78,7 +78,7 @@ executable hellos-client
       , bytestring == 0.10.*
       , containers >=0.5 && <0.7
       , grpc-haskell
-      , grpc-haskell-core
+      , grpc-haskell-core >=0.2.0
       , proto3-suite
       , proto3-wire
       , text
@@ -99,7 +99,7 @@ executable echo-server
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
-      , grpc-haskell-core
+      , grpc-haskell-core >=0.2.0
       , optparse-generic
       , proto3-suite
       , proto3-wire
@@ -124,7 +124,7 @@ executable arithmetic-server
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
-      , grpc-haskell-core
+      , grpc-haskell-core >=0.2.0
       , optparse-generic
       , proto3-suite
       , proto3-wire
@@ -148,7 +148,7 @@ executable arithmetic-client
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
-      , grpc-haskell-core
+      , grpc-haskell-core >=0.2.0
       , optparse-generic
       , proto3-suite
       , proto3-wire
@@ -172,7 +172,7 @@ executable echo-client
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
-      , grpc-haskell-core
+      , grpc-haskell-core >=0.2.0
       , optparse-generic
       , proto3-suite
       , proto3-wire


### PR DESCRIPTION
Commits are mostly atomic and can be reviewed in order; the most relevant are https://github.com/awakesecurity/gRPC-haskell/commit/85a2d138847ea654faf63d8cba895e82b1a104d4 and https://github.com/awakesecurity/gRPC-haskell/commit/eb7f78f6ab3cdb7e9c71ba967214d51b10aa60c7.

This PR intends to make our `MetadataMap` type compliant with this requirement from the [spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md):

```
Custom-Metadata header order is not guaranteed to be preserved except for values
with duplicate header names.
```

and extends the test suite accordingly.
