### PR TITLE
Derive stock instances for `MetadataMap` 

### DIFF
--- a/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC/MetadataMap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -5,6 +6,8 @@ module Network.GRPC.LowLevel.GRPC.MetadataMap where
 
 import Data.ByteString (ByteString)
 import Data.Function (on)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
 import GHC.Exts (IsList(..))
 import Data.List (sortBy, groupBy)
 import Data.Ord (comparing)
@@ -29,8 +32,9 @@ import qualified Data.Map.Strict as M
    Just "y"
 -}
 
-newtype MetadataMap = MetadataMap {unMap :: M.Map ByteString [ByteString]}
-  deriving Eq
+newtype MetadataMap = MetadataMap 
+  {unMap :: M.Map ByteString [ByteString]}
+  deriving (Data, Eq, Ord, Typeable)
 
 instance Show MetadataMap where
   show m = "fromList " ++ show (M.toList (unMap m))


### PR DESCRIPTION
This PR derives the instances `Ord`, `Data`, and `Typeable` classes for the `MetadataMap` type. The `Ord` instance is necessary for storing `MetadataMap` in ordered containers such as `Set`. The `Data` and `Typeable` instances can also be provided for `MetadataMap` via the stock deriving mechanism and are useful for SYB-style programming.

Our [`grpc-mqtt` library depends on orphans of these instances](https://github.com/awakesecurity/grpc-mqtt/blob/346c20bf4acbe1454093854a57122b20eb3e1843/src/Network/GRPC/HighLevel/Orphans.hs#L19) and it would be nice to have them canonicalized here.  

 