### PR TITLE
Increase `clock` version bounds.

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -22,7 +22,7 @@ Flag Debug
 library
   build-depends:
       base >=4.8 && <5.0
-    , clock >=0.6.0 && <0.8.0
+    , clock >=0.6.0 && <0.9
     , bytestring ==0.10.*
     , stm >=2.4 && <2.6
     , containers >=0.5 && <0.7

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -204,7 +204,7 @@ test-suite tests
     , proto3-suite
     , transformers
     , safe
-    , clock >=0.6.0 && <0.8.0
+    , clock >=0.6.0 && <0.9
     , turtle >= 1.2.0
     , text
     , QuickCheck >=2.10 && <3.0


### PR DESCRIPTION
`clock` is moving up in newer nixpkgs revisions.

Verified on nixpkgs 21.11 with clock 0.8.2 and ghc 8.10.7.