### PR TITLE
Export the constructor for the `GRPC` type

### DIFF
--- a/core/src/Network/GRPC/LowLevel/GRPC.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 
 module Network.GRPC.LowLevel.GRPC(
-GRPC
+  GRPC (GRPC)
 , withGRPC
 , GRPCIOError(..)
 , throwIfCallError

--- a/core/src/Network/GRPC/LowLevel/GRPC.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC.hs
@@ -4,8 +4,10 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 
 module Network.GRPC.LowLevel.GRPC(
-  GRPC (GRPC)
+  GRPC
 , withGRPC
+, startGRPC
+, stopGRPC
 , GRPCIOError(..)
 , throwIfCallError
 , grpcDebug
@@ -17,6 +19,7 @@ module Network.GRPC.LowLevel.GRPC(
 
 import           Control.Concurrent     (threadDelay, myThreadId)
 import           Control.Exception
+import           Data.Functor (($>))
 import           Data.Typeable
 import           Network.GRPC.LowLevel.GRPC.MetadataMap (MetadataMap(..))
 import qualified Network.GRPC.Unsafe    as C
@@ -28,8 +31,22 @@ import qualified Network.GRPC.Unsafe.Op as C
 data GRPC = GRPC
 
 withGRPC :: (GRPC -> IO a) -> IO a
-withGRPC = bracket (C.grpcInit >> return GRPC)
-                   (\_ -> grpcDebug "withGRPC: shutting down" >> C.grpcShutdown)
+withGRPC = bracket startGRPC stopGRPC 
+
+-- | Start gRPC core and obtain a 'GRPC' witness. This function does not perform
+-- any cleanup once the gRPC server is no longer needed. 
+--
+-- Where possible, consider using 'withGRPC' which handles shutdown of gRPC 
+-- automatically with 'bracket'. 
+startGRPC :: IO GRPC 
+startGRPC = C.grpcInit $> GRPC
+
+-- | Shutdown gRPC core given a 'GRPC' witnessing that gRPC core has been 
+-- initialized.
+stopGRPC :: GRPC -> IO ()
+stopGRPC GRPC = do 
+  grpcDebug "withGRPC: shutting down"
+  C.grpcShutdown
 
 -- | Describes all errors that can occur while running a GRPC-related IO
 -- action.


### PR DESCRIPTION
This PR exports the constructor `GRPC` datatype. `gRPC-haskell` uses this datatype to witness proof that gRPC server has been started. A `GRPC` value can only be obtained via the [`withGRPC`](https://github.com/awakesecurity/gRPC-haskell/blob/8bb4f062be4e92fca4bf4d5980db56547b4c116b/core/src/Network/GRPC/LowLevel/GRPC.hs#L30) function. It seems like this was done to prevent a `GRPC` value from being created without first initializing the gRPC server. 

Disallowing access to the constructor for `GRPC` makes sense, but it also makes it impossible write custom bracketing functions for initialization and cleanup of gRPC servers with `initGrpc` and `grpcShutdown`.

Having access to this constructor would be very helpful when writing tests that need to create a gRPC server for the duration of the test with [`Test.Tasty.withResource`](https://hackage.haskell.org/package/tasty-1.4.2.3/docs/Test-Tasty.html#v:withResource). Otherwise, the only option I have to obtain a `GRPC` value (as far as I know) is something like:

```haskell
import Unsafe.Coerce (unsafeCoerce)

unsafeMakeGRPC :: GRPC 
unsafeMakeGRPC = unsafeCoerce ()
```