### PR TITLE
Fix linking `grpc` for Mac

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -68,6 +68,8 @@
 let
   overlay = pkgsNew: pkgsOld: {
 
+    grpc = pkgsNew.callPackage ./nix/grpc.nix { };
+
     haskellPackages = pkgsOld.haskellPackages.override {
       overrides = haskellPackagesNew: haskellPackagesOld: rec {
         parameterized =

--- a/release.nix
+++ b/release.nix
@@ -68,8 +68,6 @@
 let
   overlay = pkgsNew: pkgsOld: {
 
-    grpc = pkgsNew.callPackage ./nix/grpc.nix { };
-
     haskellPackages = pkgsOld.haskellPackages.override {
       overrides = haskellPackagesNew: haskellPackagesOld: rec {
         parameterized =

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,7 @@
-(import ./release.nix).grpc-haskell.env
+let 
+  pkgs = import ./release.nix;
+in pkgs.grpc-haskell.env.overrideAttrs (self: {
+  buildInputs = self.buildInputs ++ [
+    pkgs.grpc
+  ];
+})


### PR DESCRIPTION
I was unable to use `shell.nix` for `grpc-haskell` due to cabal being able to locate and link the `grpc` provided by the ambient `nixpkgs`. This PR overrides the `buildInputs` for `grpc-haskell` shell, adding `grpc` explicitly since it is not (and should not be) listed within an `extra-libraries` stanza like `grpc-haskell-core`. With these changes I am now able to build `grpc-haskell` package from within the nix shell environment.