### PR TITLE
Add derived instances needed by `grpc-mqtt` 

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell-core
-version:             0.3.0
+version:             0.3.1
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0

--- a/core/src/Network/GRPC/LowLevel/GRPC.hs
+++ b/core/src/Network/GRPC/LowLevel/GRPC.hs
@@ -50,26 +50,32 @@ stopGRPC GRPC = do
 
 -- | Describes all errors that can occur while running a GRPC-related IO
 -- action.
-data GRPCIOError = GRPCIOCallError C.CallError
-                   -- ^ Errors that can occur while the call is in flight. These
-                   -- errors come from the core gRPC library directly.
-                   | GRPCIOTimeout
-                   -- ^ Indicates that we timed out while waiting for an
-                   -- operation to complete on the 'CompletionQueue'.
-                   | GRPCIOShutdown
-                   -- ^ Indicates that the 'CompletionQueue' is shutting down
-                   -- and no more work can be processed. This can happen if the
-                   -- client or server is shutting down.
-                   | GRPCIOShutdownFailure
-                   -- ^ Thrown if a 'CompletionQueue' fails to shut down in a
-                   -- reasonable amount of time.
-                   | GRPCIOUnknownError
-                   | GRPCIOBadStatusCode C.StatusCode C.StatusDetails
+data GRPCIOError 
+  = GRPCIOCallError C.CallError
+    -- ^ Errors that can occur while the call is in flight. These
+    -- errors come from the core gRPC library directly.
+  | GRPCIOTimeout
+    -- ^ Indicates that we timed out while waiting for an
+    -- operation to complete on the 'CompletionQueue'.
+  | GRPCIOShutdown
+    -- ^ Indicates that the 'CompletionQueue' is shutting down
+    -- and no more work can be processed. This can happen if the
+    -- client or server is shutting down.
+  | GRPCIOShutdownFailure
+    -- ^ Thrown if a 'CompletionQueue' fails to shut down in a
+    -- reasonable amount of time.
+  | GRPCIOUnknownError
+  | GRPCIOBadStatusCode C.StatusCode C.StatusDetails
+  | GRPCIODecodeError String
+  | GRPCIOInternalUnexpectedRecv String -- debugging description
+  | GRPCIOHandlerException String
+  deriving 
+    ( Eq
+    , Ord -- ^ @since 0.3.1
+    , Show
+    , Typeable
+    )
 
-                   | GRPCIODecodeError String
-                   | GRPCIOInternalUnexpectedRecv String -- debugging description
-                   | GRPCIOHandlerException String
-  deriving (Eq, Show, Typeable)
 instance Exception GRPCIOError
 
 throwIfCallError :: C.CallError -> Either GRPCIOError ()

--- a/core/src/Network/GRPC/LowLevel/Op.hs
+++ b/core/src/Network/GRPC/LowLevel/Op.hs
@@ -334,7 +334,7 @@ writesDonePrim c cq = f <$> runOps c cq [OpSendCloseFromClient]
 -- to a valid gRPC 'StatusCode' (i.e. some integer @(i ::'Int')@ less than @0@
 -- or greater than @16@), then 'intToStatusCode' will return 'Nothing'.
 --
--- @since 3.0.1
+-- @since 0.3.1
 intToStatusCode :: Int -> Maybe StatusCode 
 intToStatusCode i 
   | lower <= i && i <= upper = Just (toEnum i)

--- a/core/src/Network/GRPC/LowLevel/Op.hs
+++ b/core/src/Network/GRPC/LowLevel/Op.hs
@@ -19,6 +19,7 @@ import           Foreign.Storable                      (peek)
 import           Network.GRPC.LowLevel.CompletionQueue
 import           Network.GRPC.LowLevel.GRPC
 import qualified Network.GRPC.Unsafe                   as C (Call)
+import           Network.GRPC.Unsafe.Op                (StatusCode)
 import qualified Network.GRPC.Unsafe.ByteBuffer        as C
 import qualified Network.GRPC.Unsafe.Metadata          as C
 import qualified Network.GRPC.Unsafe.Op                as C
@@ -325,3 +326,22 @@ writesDonePrim c cq = f <$> runOps c cq [OpSendCloseFromClient]
     f (Right []) = Right ()
     f Right{}    = Left (GRPCIOInternalUnexpectedRecv "writesDonePrim")
     f (Left e)   = Left e
+
+--------------------------------------------------------------------------------
+
+-- | Convert an 'Int' to a 'StatusCode' according to integer codes that 
+-- corresponds to each gRPC status code. If the given 'Int' does not correspond 
+-- to a valid gRPC 'StatusCode' (i.e. some integer @(i ::'Int')@ less than @0@
+-- or greater than @16@), then 'intToStatusCode' will return 'Nothing'.
+--
+-- @since 3.0.1
+intToStatusCode :: Int -> Maybe StatusCode 
+intToStatusCode i 
+  | lower <= i && i <= upper = Just (toEnum i)
+  | otherwise                = Nothing
+  where 
+    lower :: Int 
+    lower = fromEnum (minBound :: StatusCode)
+
+    upper :: Int 
+    upper = fromEnum (maxBound :: StatusCode)

--- a/core/src/Network/GRPC/Unsafe.chs
+++ b/core/src/Network/GRPC/Unsafe.chs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 
 module Network.GRPC.Unsafe where
@@ -29,8 +30,16 @@ import Network.GRPC.Unsafe.Constants
 
 {#context prefix = "grpc" #}
 
-newtype StatusDetails = StatusDetails {unStatusDetails :: ByteString}
-  deriving (Eq, IsString, Monoid, Semigroup, Show)
+-- | A message that carry the details about a 'StatusCode'. Typical usage will 
+-- only provide descriptions of 'StatusCode' in a 'StatusDetails' when the 
+-- status-code is an error. 
+newtype StatusDetails = StatusDetails 
+  {unStatusDetails :: ByteString}
+  deriving newtype 
+    ( Eq
+    , Ord -- ^ @since 0.3.1
+    , IsString, Monoid, Semigroup, Show
+    )
 
 {#pointer *grpc_completion_queue as CompletionQueue newtype #}
 
@@ -98,7 +107,10 @@ newtype Reserved = Reserved {unReserved :: Ptr ()}
 reserved :: Reserved
 reserved = Reserved nullPtr
 
-{#enum grpc_call_error as CallError {underscoreToCase} deriving (Show, Eq)#}
+{#enum 
+  grpc_call_error as CallError {underscoreToCase} 
+    deriving (Bounded, Eq, Ord, Show)
+  #}
 
 -- | Represents the type of a completion event on a 'CompletionQueue'.
 -- 'QueueShutdown' only occurs if the queue is shutting down (e.g., when the

--- a/core/src/Network/GRPC/Unsafe/Op.chs
+++ b/core/src/Network/GRPC/Unsafe/Op.chs
@@ -17,7 +17,12 @@ import Foreign.Ptr
 {#context prefix = "grpc" #}
 
 {#enum grpc_op_type as OpType {underscoreToCase} deriving (Eq, Show)#}
-{#enum grpc_status_code as StatusCode {underscoreToCase} deriving (Eq, Read, Show)#}
+
+-- | A set of well defined status codes RPCs use.
+{#enum 
+  grpc_status_code as StatusCode {underscoreToCase} 
+    deriving (Bounded, Eq, Ord, Read, Show)
+  #}
 
 -- NOTE: We don't alloc the space for the enum in Haskell because enum size is
 -- implementation-dependent. See:

--- a/core/src/Network/GRPC/Unsafe/Op.chs
+++ b/core/src/Network/GRPC/Unsafe/Op.chs
@@ -27,6 +27,7 @@ import Foreign.Ptr
 -- NOTE: We don't alloc the space for the enum in Haskell because enum size is
 -- implementation-dependent. See:
 -- http://stackoverflow.com/questions/1113855/is-the-sizeofenum-sizeofint-always
+
 -- | Allocates space for a 'StatusCode' and returns a pointer to it. Used to
 -- receive a status code from the server with 'opRecvStatusClient'.
 {#fun unsafe create_status_code_ptr as ^ {} -> `Ptr StatusCode' castPtr#}

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell
-version:             0.3.0
+version:             0.3.1
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0

--- a/release.nix
+++ b/release.nix
@@ -68,8 +68,6 @@
 let
   overlay = pkgsNew: pkgsOld: {
 
-    grpc = pkgsNew.callPackage ./nix/grpc.nix { };
-
     haskellPackages = pkgsOld.haskellPackages.override {
       overrides = haskellPackagesNew: haskellPackagesOld: rec {
         parameterized =

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,7 @@
-(import ./release.nix).grpc-haskell.env
+let 
+  pkgs = import ./release.nix;
+in pkgs.grpc-haskell.env.overrideAttrs (self: {
+  buildInputs = self.buildInputs ++ [
+    pkgs.grpc
+  ];
+})


### PR DESCRIPTION
This PR includes a number of instances that [`grpc-mqtt`](https://github.com/awakesecurity/grpc-mqtt) depends on. These changes will keep [`grpc-mqtt`](https://github.com/awakesecurity/grpc-mqtt) from needing to declare orphaned instance declarations in order to make use of these instances.