### PR TITLE
Derive stock `StatusCode` instances

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell-core
-version:             0.3.0
+version:             0.4.0
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0
@@ -21,16 +21,18 @@ Flag Debug
 
 library
   build-depends:
-      base >=4.8 && <5.0
-    , clock >=0.6.0 && <0.9
-    , bytestring ==0.10.*
-    , stm >=2.4 && <2.6
-    , containers >=0.5 && <0.7
-    , managed >= 1.0.0 && < 1.1
+      base             >= 4.8    && < 5.0
+    , clock            >= 0.6.0  && < 0.9
+    , bytestring       == 0.10.*
+    , stm              >= 2.4    && < 2.6
+    , containers       >= 0.5    && < 0.7
+    , managed          >= 1.0.0  && < 1.1
+    , template-haskell >= 2.16.0 && < 2.21
     , transformers
 
   c-sources:
     cbits/grpc_haskell.c
+
   exposed-modules:
   -- NOTE: the order of these matters to c2hs.
     Network.GRPC.Unsafe.Constants

--- a/core/src/Network/GRPC/Unsafe/Op.chs
+++ b/core/src/Network/GRPC/Unsafe/Op.chs
@@ -1,16 +1,18 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingVia        #-}
+{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Network.GRPC.Unsafe.Op where
 
 import Data.Data (Data)
 
-import GHC.Generics (Generic)
-
 import Foreign.C.Types
 import Foreign.Ptr
+
+import GHC.Generics (Generic)
+
+import Language.Haskell.TH.Syntax (Lift)
 
 {#import Network.GRPC.Unsafe.Slice#}
 {#import Network.GRPC.Unsafe.ByteBuffer#}

--- a/core/src/Network/GRPC/Unsafe/Op.chs
+++ b/core/src/Network/GRPC/Unsafe/Op.chs
@@ -30,7 +30,7 @@ import Foreign.Ptr
 -- library reference for more information regarding the 'StatusCode' enum. 
 {#enum 
   grpc_status_code as StatusCode {underscoreToCase} 
-    deriving (Bounded, Data, Eq, Generic, Ord, Read, Show)
+    deriving (Bounded, Data, Eq, Generic, Lift, Ord, Read, Show)
   #}
 
 -- | Allocates space for a 'StatusCode' and returns a pointer to it. Used to


### PR DESCRIPTION
This PR derives the stock `Bounded`, `Data`, `Generic`, `Lift`, and `Ord` instances for the [`StatusCode`](https://hackage.haskell.org/package/grpc-haskell-0.1.0/docs/Network-GRPC-HighLevel.html#t:StatusCode) enum.