### PR TITLE
Bump `cachix` version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: true
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-10.15
+        os: [ubuntu-latest, macos-latest]
+      max-parallel: 2
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,8 @@ on:
       - master
   pull_request:
 jobs:
-  build:
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-      max-parallel: 2
-    runs-on: ${{ matrix.os }}
+  build-linux:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
         name: Checkout
@@ -23,3 +18,16 @@ jobs:
           name: awakesecurity
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix-build --attr grpc-haskell
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+        name: Checkout
+      - uses: cachix/install-nix-action@v20 
+        name: Install Nix
+      - uses: cachix/cachix-action@v12
+        name: Set up Cachix
+        with:
+          name: awakesecurity
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix-build --attr grpc-haskell-no-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
           - macos-10.15
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.0.2
         name: Checkout
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v20 
         name: Install Nix
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         name: Set up Cachix
         with:
           name: awakesecurity


### PR DESCRIPTION
This PR fixes CI failures by bumping the `cachix` Git action as suggested in #148. 