### PR TITLE
Upgrade to `install-nix-action@v22`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
         name: Checkout
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         name: Install Nix
       - uses: cachix/cachix-action@v12
         name: Set up Cachix
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
         name: Checkout
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         name: Install Nix
       - uses: cachix/cachix-action@v12
         name: Set up Cachix


### PR DESCRIPTION
Fixing `install-nix-action` once again based on a something @fumieval noted in #140. Apparently upgrading to `install-nix-action@v22` should fix the following issue for OSX:

```
  ---- Reminders -----------------------------------------------------------------
  [ 1 ]
  Nix won't work in active shell sessions until you restart them.
  
  Could not set environment: 150: Operation not permitted while System Integrity Protection is engaged
  Error: Process completed with exit code 150.
```