### PR TITLE
Support build grpc-haskell with ghc-9.2.8 without nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 .stack-work/
+stack*.lock
 *.pyc
 *.pyo
 *.o

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -23,7 +23,7 @@ library
   build-depends:
       base             >= 4.8    && < 5.0
     , clock            >= 0.6.0  && < 0.9
-    , bytestring       == 0.10.*
+    , bytestring       >= 0.10 && <0.12
     , stm              >= 2.4    && < 2.6
     , containers       >= 0.5    && < 0.7
     , managed          >= 1.0.0  && < 1.1
@@ -83,7 +83,7 @@ test-suite tests
   build-depends:
       base >=4.8 && <5.0
     , grpc-haskell-core
-    , bytestring ==0.10.*
+    , bytestring >= 0.10 && <0.12
     , unix
     , time
     , async >=2.1 && <2.3

--- a/stack-20.26.yaml
+++ b/stack-20.26.yaml
@@ -1,0 +1,13 @@
+resolver: lts-20.26
+
+packages:
+- '.'
+- 'core'
+
+extra-deps:
+- git: git@github.com:awakesecurity/proto3-suite.git
+  commit: 5beaf4ab206b5c82a2161dd0850e91b3663135ec
+- git: git@github.com:awakesecurity/proto3-wire.git
+  commit: ee6ca644eef86cc5f31da85fb48e10b20ab0e1a1
+- large-generics-0.2.1
+- large-records-0.4


### PR DESCRIPTION
As the title described.