### PR TITLE
Bump bytestring upper bound

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -23,7 +23,7 @@ library
   build-depends:
       base             >= 4.8    && < 5.0
     , clock            >= 0.6.0  && < 0.9
-    , bytestring       >= 0.10 && <0.12
+    , bytestring       >= 0.10 && <0.16
     , stm              >= 2.4    && < 2.6
     , containers       >= 0.5    && < 0.7
     , managed          >= 1.0.0  && < 1.1
@@ -83,7 +83,7 @@ test-suite tests
   build-depends:
       base >=4.8 && <5.0
     , grpc-haskell-core
-    , bytestring >= 0.10 && <0.12
+    , bytestring >= 0.10 && <0.16
     , unix
     , time
     , async >=2.1 && <2.3

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -55,7 +55,7 @@ executable hellos-server
     build-depends:
       base >=4.8 && <5.0
       , async
-      , bytestring >= 0.10 && <0.12
+      , bytestring >= 0.10 && <0.16
       , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core >=0.2.0
@@ -75,7 +75,7 @@ executable hellos-client
     build-depends:
       base >=4.8 && <5.0
       , async
-      , bytestring >= 0.10 && <0.12
+      , bytestring >= 0.10 && <0.16
       , containers >=0.5 && <0.7
       , grpc-haskell
       , grpc-haskell-core >=0.2.0
@@ -95,7 +95,7 @@ executable echo-server
     build-depends:
       base >=4.8 && <5.0
       , async
-      , bytestring >= 0.10 && <0.12
+      , bytestring >= 0.10 && <0.16
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
@@ -120,7 +120,7 @@ executable arithmetic-server
     build-depends:
       base >=4.8 && <5.0
       , async
-      , bytestring >= 0.10 && <0.12
+      , bytestring >= 0.10 && <0.16
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
@@ -144,7 +144,7 @@ executable arithmetic-client
     build-depends:
       base >=4.8 && <5.0
       , async
-      , bytestring >= 0.10 && <0.12
+      , bytestring >= 0.10 && <0.16
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
@@ -168,7 +168,7 @@ executable echo-client
     build-depends:
       base >=4.8 && <5.0
       , async
-      , bytestring >= 0.10 && <0.12
+      , bytestring >= 0.10 && <0.16
       , containers >=0.5 && <0.7
       , deepseq
       , grpc-haskell
@@ -191,7 +191,7 @@ executable echo-client
 test-suite tests
   build-depends:
       base >=4.8 && <5.0
-    , bytestring >= 0.10 && <0.12
+    , bytestring >= 0.10 && <0.16
     , unix
     , time
     , async
@@ -228,7 +228,7 @@ benchmark bench
     , async ==2.1.*
     , criterion ==1.1.*
     , proto3-suite
-    , bytestring >= 0.10 && <0.12
+    , bytestring >= 0.10 && <0.16
     , random >=1.0.0
   hs-source-dirs: bench
   main-is: Bench.hs

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -28,7 +28,7 @@ flag with-examples
 library
   build-depends:
       base >=4.8 && <5.0
-    , bytestring >= 0.10 && <0.12
+    , bytestring >= 0.10 && <0.16
     , proto3-suite >=0.4.3
     , proto3-wire >=1.2.2
     , grpc-haskell-core >=0.2.1


### PR DESCRIPTION
Hi! Is it possible to bump an upper bound of the `bytestring` dependency? 