### PR TITLE
Remove `StatusDoNotUse` enum from `StatusCode`

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -54,7 +54,6 @@ library
     Network.GRPC.LowLevel.GRPC.MetadataMap
     Network.GRPC.LowLevel.Op
     Network.GRPC.LowLevel.Server
-    -- Network.GRPC.LowLevel.StatusCode
     Network.GRPC.LowLevel.Call
     Network.GRPC.LowLevel.Call.Unregistered
     Network.GRPC.LowLevel.Client

--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell-core
-version:             0.5.0
+version:             0.6.0
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0
@@ -54,12 +54,15 @@ library
     Network.GRPC.LowLevel.GRPC.MetadataMap
     Network.GRPC.LowLevel.Op
     Network.GRPC.LowLevel.Server
+    -- Network.GRPC.LowLevel.StatusCode
     Network.GRPC.LowLevel.Call
     Network.GRPC.LowLevel.Call.Unregistered
     Network.GRPC.LowLevel.Client
+
   extra-libraries:
       grpc
     , gpr
+
   includes:
       include/grpc_haskell.h
     , grpc/grpc.h

--- a/core/src/Network/GRPC/Unsafe/Op.chs
+++ b/core/src/Network/GRPC/Unsafe/Op.chs
@@ -27,11 +27,12 @@ import Language.Haskell.TH.Syntax (Lift)
 
 -- StatusCode ------------------------------------------------------------------
 
--- | 'StatusCode' enumerates the set of gRPC status codes. See the 
+-- | 'StatusCode' enumerates the set of gRPC status codes. See the
 -- ["gRPC Core"](https://grpc.github.io/grpc/core/md_doc_statuscodes.html)
--- library reference for more information regarding the 'StatusCode' enum. 
-{#enum 
-  grpc_status_code as StatusCode {underscoreToCase} 
+-- library reference for more information regarding the 'StatusCode' enum.
+{#enum
+  grpc_status_code as StatusCode {underscoreToCase}
+    omit (GRPC_STATUS__DO_NOT_USE)
     deriving (Bounded, Data, Eq, Generic, Lift, Ord, Read, Show)
   #}
 
@@ -45,8 +46,8 @@ import Language.Haskell.TH.Syntax (Lift)
 
 --------------------------------------------------------------------------------
 
-{#enum 
-  grpc_op_type as OpType {underscoreToCase} 
+{#enum
+  grpc_op_type as OpType {underscoreToCase}
     deriving (Eq, Show)
   #}
 
@@ -60,9 +61,9 @@ import Language.Haskell.TH.Syntax (Lift)
 -- always the OpArray to mutate and the index in the array at which to create
 -- the new op. After processing the batch and getting out any results, call
 -- 'opArrayDestroy'.
-{#pointer 
+{#pointer
 
-  *grpc_op as OpArray newtype 
+  *grpc_op as OpArray newtype
   #}
 
 deriving instance Show OpArray

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -1,5 +1,5 @@
 name:                grpc-haskell
-version:             0.3.0
+version:             0.4.0
 synopsis:            Haskell implementation of gRPC layered on shared C library.
 homepage:            https://github.com/awakenetworks/gRPC-haskell
 license:             Apache-2.0
@@ -31,7 +31,7 @@ library
     , bytestring >= 0.10 && <0.12
     , proto3-suite >=0.4.3
     , proto3-wire >=1.2.2
-    , grpc-haskell-core >=0.2.1
+    , grpc-haskell-core >=0.6.0
     , async >=2.1 && <2.3
     , managed >= 1.0.5
 


### PR DESCRIPTION
This PR removes the `StatusDoNotUse` enum from `StatusCode` since gRPC documentation explicitly says that the `STATUS__DO_NOT_USE` enum should never be used.  