### PR TITLE
Fix build with GCC15

### DIFF
--- a/core/grpc-haskell-core.cabal
+++ b/core/grpc-haskell-core.cabal
@@ -83,9 +83,10 @@ library
   hs-source-dirs:       src
   default-extensions:   CPP
   CC-Options: -std=c99
+  CPP-Options: -std=c99
   if flag(debug)
     CPP-Options: -DDEBUG
-    CC-Options:  -DGRPC_HASKELL_DEBUG -std=c99
+    CC-Options:  -DGRPC_HASKELL_DEBUG
 
 test-suite tests
   import:               common

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -7,7 +7,7 @@
 # The SHA256 will be printed as the last line of stdout.
 
 import (builtins.fetchTarball {
-    # "nixos-unstable" as on 2025-11-27
-    url    = "https://github.com/NixOS/nixpkgs/archive/5ae3b07d8d6527c42f17c876e404993199144b6a.tar.gz";
-    sha256 = "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=";
+    # "nixos-unstable" as on 2026-01-06
+    url    = "https://github.com/NixOS/nixpkgs/archive/9f0c42f8bc7151b8e7e5840fb3bd454ad850d8c5.tar.gz";
+    sha256 = "sha256-UWYqmD7JFBEDBHWYcqE6s6c77pWdcU/i+bwD6XxMb8A=";
   })

--- a/release.nix
+++ b/release.nix
@@ -70,6 +70,10 @@ let
 
     haskellPackages = pkgsOld.haskell.packages.${ghc}.override {
       overrides = haskellPackagesNew: haskellPackagesOld: {
+        vcr = pkgsNew.lib.pipe haskellPackagesOld.vcr [
+          (pkgsNew.haskell.lib.compose.dontCheckIf pkgsNew.stdenv.hostPlatform.isDarwin)
+        ];
+
         proto3-wire =
           haskellPackagesNew.callPackage ./nix/proto3-wire.nix { };
 
@@ -211,7 +215,7 @@ let
 
    nixpkgs = import ./nixpkgs.nix;
    linuxPkgs = nixpkgs { inherit config overlays; system = "x86_64-linux" ; };
-  darwinPkgs = nixpkgs { inherit config overlays; system = "x86_64-darwin"; };
+  darwinPkgs = nixpkgs { inherit config overlays; system = "aarch64-darwin"; };
         pkgs = nixpkgs { inherit config overlays; };
 
 in


### PR DESCRIPTION
> GCC 15 changes the default language version for C compilation from -std=gnu17 to -std=gnu23.

Building the cbits with C23 breaks bools:
```
> c2hs: C header contains errors:
>
> /nix/store/n0zhrw9b9jky2fb3x4dr030agmw8izd7-grpc-1.76.0/include/grpc/credentials.h:231: (column 3) [ERROR]  >>> Syntax error !
>   The symbol `bool' does not fit here.
```

We already set `CC-Options: -std=c99` but c2hs doesn't respect that and uses `CPP-Options` instead :(